### PR TITLE
fix: Claude Code Review の PR 書き込み権限を修正

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
## Summary
- `claude-code-review.yml` の `permissions.pull-requests` を `read` → `write` に変更
- レビュー結果が PR コメントとして投稿されるようにする

Closes #15

## Test plan
- [ ] この PR 自体に Claude Code Review のコメントが投稿されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)