### PR TITLE
debug: Claude Code Review のフル出力を有効化して原因調査

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          show_full_output: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- Claude Code Review ワークフローに `show_full_output: true` を追加
- `permission_denials_count: 3` の詳細をログに出力し、レビューコメントが投稿されない原因を特定する

## 背景
- PR #18 等でワークフローは成功するが、レビューコメントが0件（`No buffered inline comments`）
- ログで `permission_denials_count: 3` が確認されるが、`show_full_output: false` のため拒否されたツール名が不明

## 次のステップ
1. この PR のワークフローログから拒否されたツールを特定
2. 原因に応じて `claude_args: '--allowedTools ...'` 等で修正

Refs #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)