### PR TITLE
fix: Claude Code Review に必要最小限の Bash 権限を付与

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,7 +39,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          show_full_output: true
+          claude_args: '--allowedTools "Bash(gh pr diff:*)" --allowedTools "Bash(gh pr view:*)" --allowedTools "Bash(git diff:*)"'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- code-review プラグインが `gh pr diff` 実行時に Bash ツールが permission denied されていた問題を修正
- `claude_args` で `gh pr diff`, `gh pr view`, `git diff` のみ許可
- デバッグ用の `show_full_output: true` を削除

## 原因
`show_full_output: true` で取得したログから、以下のツール呼び出しが拒否されていることを確認:
```json
{
  "tool_name": "Bash",
  "tool_input": {
    "command": "gh pr diff shiroinock/keyviz/pull/21"
  }
}
```

## Test plan
- [ ] この PR のマージ後、別 PR で Claude Code Review ワークフローが実行され、レビューコメントが投稿されることを確認

Refs #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)