### PR TITLE
feat: サブエージェントのモデル選定を見直す

### DIFF
--- a/.claude/agents/classify-files.md
+++ b/.claude/agents/classify-files.md
@@ -1,7 +1,7 @@
 ---
 name: classify-files
 description: 変更されたファイルを分析し、各ファイルに適用すべきレビュー観点とテストパターンを判定するエージェント
-model: haiku
+model: sonnet
 ---
 
 # ファイル分類エージェント

--- a/.claude/agents/plan-fix.md
+++ b/.claude/agents/plan-fix.md
@@ -1,7 +1,7 @@
 ---
 name: plan-fix
 description: レビュー結果を分析し、修正計画を立案するエージェント。修正可能な問題を特定し、具体的な修正指示を作成する。
-model: haiku
+model: opus
 ---
 
 # 修正計画エージェント

--- a/.claude/agents/review-file.md
+++ b/.claude/agents/review-file.md
@@ -1,7 +1,7 @@
 ---
 name: review-file
 description: 単一ファイルを指定された観点でレビューするエージェント
-model: haiku
+model: opus
 ---
 
 # ファイル単位レビューエージェント

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -2,7 +2,7 @@
 name: test-runner
 description: テスト実行とRed/Green状態判定を行うエージェント。TDDサイクルの状態遷移を管理する。
 allowed-tools: Bash
-model: haiku
+model: sonnet
 ---
 
 # test-runner エージェント

--- a/.claude/skills/tdd-next/SKILL.md
+++ b/.claude/skills/tdd-next/SKILL.md
@@ -258,7 +258,7 @@ test-writer の出力:
 ```javascript
 {
   "subagent_type": "classify-files",
-  "model": "haiku",
+  "model": "sonnet",
   "prompt": "Issue #{番号}「{タイトル}」について、実装対象ファイルのテストパターンを判定してください。..."
 }
 ```
@@ -276,7 +276,7 @@ test-writer の出力:
 ```javascript
 {
   "subagent_type": "test-runner",
-  "model": "haiku",
+  "model": "sonnet",
   "prompt": "{testFilePath} のテストを実行し、{expectation} であることを確認してください。"
 }
 ```
@@ -294,7 +294,7 @@ test-writer の出力:
 ```javascript
 {
   "subagent_type": "review-file",
-  "model": "haiku",
+  "model": "opus",
   "prompt": "review-perspective-selector skill を使用して {implFilePath} に適切なレビュー観点を選択してください。..."
 }
 ```
@@ -303,7 +303,7 @@ test-writer の出力:
 ```javascript
 {
   "subagent_type": "plan-fix",
-  "model": "haiku",
+  "model": "opus",
   "prompt": "review-file の指摘事項に基づき、{implFilePath} の修正計画を作成してください。"
 }
 ```


### PR DESCRIPTION
## Summary
- classify-files, test-runner を haiku → **sonnet** に昇格（構造化された判定・分類タスク）
- review-file, plan-fix を haiku → **opus** に昇格（深い分析・品質の門番）
- tdd-next スキルのエージェント起動例のモデル指定を同期

Closes #17

## Test plan
- [x] Biome check: PASS
- [x] Tests: PASS (78 tests)
- [x] Build: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)