### PR TITLE
fix: code-review プラグインの不足ツール権限を追加

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,7 +39,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          claude_args: '--allowedTools "Bash(gh pr diff:*)" --allowedTools "Bash(gh pr view:*)" --allowedTools "Bash(git diff:*)"'
+          claude_args: '--allowedTools "Bash(gh pr diff:*)" --allowedTools "Bash(gh pr view:*)" --allowedTools "Bash(git diff:*)" --allowedTools "Bash(gh issue view:*)" --allowedTools "Bash(gh search:*)" --allowedTools "Bash(gh issue list:*)" --allowedTools "Bash(gh pr comment:*)" --allowedTools "Bash(gh pr list:*)" --allowedTools "mcp__github_inline_comment__create_inline_comment"'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- code-review プラグインが必要とする全ツール権限を `claude_args` に追加
- インラインコメント投稿用の MCP ツール権限を追加
- Issue/PR 参照・検索系の gh コマンド権限を追加

## 追加した権限
| ツール | 用途 |
|-------|------|
| `Bash(gh issue view:*)` | Issue 参照 |
| `Bash(gh search:*)` | 検索 |
| `Bash(gh issue list:*)` | Issue 一覧 |
| `Bash(gh pr comment:*)` | PR コメント投稿 |
| `Bash(gh pr list:*)` | PR 一覧 |
| `mcp__github_inline_comment__create_inline_comment` | インラインコメント投稿 |

## 注意事項
ワークフローファイル自体を変更する PR では OIDC トークン検証が失敗するため、**マージ後の次回 PR から有効**になります。

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)