### PR TITLE
feat: CI ワークフローに paths-ignore を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,20 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - '.claude/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '**/*.md'
+      - 'LICENSE'
+      - '.gitignore'
   push:
     branches: [main]
+    paths-ignore:
+      - '.claude/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '**/*.md'
+      - 'LICENSE'
+      - '.gitignore'
 
 permissions:
   contents: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,6 +3,11 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
+    paths-ignore:
+      - '.claude/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '**/*.md'
+      - 'LICENSE'
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"


### PR DESCRIPTION
## Summary
- `.github/workflows/ci.yml` の `on.pull_request` と `on.push` に `paths-ignore` を追加
- `.github/workflows/claude-code-review.yml` の `on.pull_request` に `paths-ignore` を追加
- `.claude/**`, `.github/ISSUE_TEMPLATE/**`, `**/*.md`, `LICENSE`, `.gitignore` の変更時は CI / Code Review をスキップ

Closes #27

## Test plan
- [ ] `.claude/` 配下のみの変更で CI がスキップされることを確認
- [ ] `*.md` ファイルのみの変更で CI がスキップされることを確認
- [ ] `src/**` 等コード変更では従来通り CI が実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)