### PR TITLE
fix: issue-enrichment の候補から status:in-progress を除外

### DIFF
--- a/.claude/skills/issue-enrichment/SKILL.md
+++ b/.claude/skills/issue-enrichment/SKILL.md
@@ -14,11 +14,11 @@ user-invocable: true
 ### 1. 対象 Issue の選定
 
 ```bash
-# status:ready でない open Issue を取得
-gh issue list --state open --limit 10 --json number,title,labels,body
+# status:ready でも status:in-progress でもない open Issue を取得
+gh issue list --state open --limit 10 --exclude-labels "status:ready,status:in-progress" --json number,title,labels,body
 ```
 
-- `status:ready` ラベルが**ない** Issue を候補として表示
+- `status:ready` および `status:in-progress` ラベルが**ない** Issue を候補として表示
 - ユーザーに対象 Issue を確認
 
 ### 2. コードベース探索


### PR DESCRIPTION
## Summary
- `issue-enrichment` スキルの `gh issue list` に `--exclude-labels "status:ready,status:in-progress"` を追加
- 実装進行中の Issue が enrichment 候補に表示されなくなる

Closes #34

## Test plan
- [ ] `status:in-progress` ラベル付き Issue が存在する状態で `/issue-enrichment` を実行し、候補に含まれないことを確認
- [ ] ラベルなしの Issue が従来通り候補に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)