### PR TITLE
debug: Claude Code Review のフルログ出力を有効化

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,6 +44,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          show_full_output: true
           claude_args: '--allowedTools "Bash(gh pr diff:*)" --allowedTools "Bash(gh pr view:*)" --allowedTools "Bash(git diff:*)" --allowedTools "Bash(gh issue view:*)" --allowedTools "Bash(gh search:*)" --allowedTools "Bash(gh issue list:*)" --allowedTools "Bash(gh pr comment:*)" --allowedTools "Bash(gh pr list:*)" --allowedTools "mcp__github_inline_comment__create_inline_comment"'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary
- `show_full_output: true` を追加し、レビューワークフローのフルログを出力する
- `permission_denials_count: 1` で拒否されているツールの特定が目的

Refs #37

## Test plan
- [ ] この PR のレビューワークフロー実行ログでフル出力が確認できること
- [ ] deny されたツール名がログから特定できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)