### PR TITLE
fix: issue-enrichment の --exclude-labels を --search に置換

### DIFF
--- a/.claude/skills/issue-enrichment/SKILL.md
+++ b/.claude/skills/issue-enrichment/SKILL.md
@@ -15,7 +15,7 @@ user-invocable: true
 
 ```bash
 # status:ready でも status:in-progress でもない open Issue を取得
-gh issue list --state open --limit 10 --exclude-labels "status:ready,status:in-progress" --json number,title,labels,body
+gh issue list --state open --limit 10 --search "-label:status:ready -label:status:in-progress" --json number,title,labels,body
 ```
 
 - `status:ready` および `status:in-progress` ラベルが**ない** Issue を候補として表示


### PR DESCRIPTION
## Summary
- `gh issue list` に存在しない `--exclude-labels` フラグを `--search "-label:..."` に修正

## Test plan
- [ ] `/issue-enrichment` 実行時に `status:ready` / `status:in-progress` の Issue が候補から除外されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)