### PR TITLE
feat: KeyboardEvent を Vim 表記に変換する normalizeKeyEvent を追加

### DIFF
--- a/src/utils/key-event.test.ts
+++ b/src/utils/key-event.test.ts
@@ -9,7 +9,7 @@ describe("normalizeKeyEvent", () => {
     });
 
     it("大文字キーをそのまま返す", () => {
-      const e = new KeyboardEvent("keydown", { key: "A" });
+      const e = new KeyboardEvent("keydown", { key: "A", shiftKey: true });
       expect(normalizeKeyEvent(e)).toBe("A");
     });
 

--- a/src/utils/key-event.ts
+++ b/src/utils/key-event.ts
@@ -39,7 +39,10 @@ export function normalizeKeyEvent(e: KeyboardEvent): string {
   // 修飾プレフィックスを C, S, A, M の順で構築
   const modifierFlags: [boolean, string][] = [
     [e.ctrlKey, MODIFIER_PREFIX_MAP.Control],
-    [e.shiftKey, MODIFIER_PREFIX_MAP.Shift],
+    [
+      e.shiftKey && (isSpecial || e.ctrlKey || e.altKey || e.metaKey),
+      MODIFIER_PREFIX_MAP.Shift,
+    ],
     [e.altKey, MODIFIER_PREFIX_MAP.Alt],
     [e.metaKey, MODIFIER_PREFIX_MAP.Meta],
   ];


### PR DESCRIPTION
## Summary
- `normalizeKeyEvent(e: KeyboardEvent): string` 純粋関数を新規作成
- 修飾キー（Ctrl/Shift/Alt/Meta）を `<C-x>`, `<S-x>`, `<A-x>`, `<M-x>` 形式に変換
- 特殊キー（Enter, Escape, Tab, Space, 矢印キー等）を Vim 表記に変換
- 修飾キー単体の押下は空文字列を返す

Closes #43

## Test plan
- [x] 通常キー入力の変換（a → a, A → A, 1 → 1）
- [x] 特殊キーの変換（Enter → `<CR>`, Escape → `<Esc>` 等 10 件）
- [x] 修飾キー単体は空文字列（Control, Shift, Alt, Meta）
- [x] 修飾キー + 通常キーの組み合わせ（Ctrl+f → `<C-f>` 等 6 件）
- [x] 複数修飾キーの組み合わせと順序（C, S, A, M 順 — 5 件）
- [x] 28 テスト全パス、Biome check / Build クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)