### PR TITLE
feat: プリセット配列データの定義

### DIFF
--- a/src/data/keybinding-presets.test.ts
+++ b/src/data/keybinding-presets.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { getPresets } from "./keybinding-presets";
+import { defaultCustomKeymap } from "./keymap";
+
+const QWERTY_30_KEYS = [
+  "q",
+  "w",
+  "e",
+  "r",
+  "t",
+  "y",
+  "u",
+  "i",
+  "o",
+  "p",
+  "a",
+  "s",
+  "d",
+  "f",
+  "g",
+  "h",
+  "j",
+  "k",
+  "l",
+  ";",
+  "z",
+  "x",
+  "c",
+  "v",
+  "b",
+  "n",
+  "m",
+  ",",
+  ".",
+  "/",
+];
+
+describe("getPresets", () => {
+  describe("戻り値の基本構造", () => {
+    it("配列を返す", () => {
+      const result = getPresets();
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    it("4つ以上のプリセットを返す", () => {
+      const result = getPresets();
+      expect(result.length).toBeGreaterThanOrEqual(4);
+    });
+  });
+
+  describe("各プリセットの形状", () => {
+    it("全プリセットが id, name, description, keymap を持つ", () => {
+      const presets = getPresets();
+      for (const preset of presets) {
+        expect(preset).toHaveProperty("id");
+        expect(preset).toHaveProperty("name");
+        expect(preset).toHaveProperty("description");
+        expect(preset).toHaveProperty("keymap");
+        expect(typeof preset.id).toBe("string");
+        expect(typeof preset.name).toBe("string");
+        expect(typeof preset.description).toBe("string");
+        expect(typeof preset.keymap).toBe("object");
+      }
+    });
+
+    it("全プリセットの keymap が 30 キーを持つ", () => {
+      const presets = getPresets();
+      for (const preset of presets) {
+        const keys = Object.keys(preset.keymap);
+        expect(keys).toHaveLength(30);
+      }
+    });
+
+    it("全プリセットの keymap のキーセットが QWERTY 30 キーと一致する", () => {
+      const presets = getPresets();
+      for (const preset of presets) {
+        const keys = Object.keys(preset.keymap).sort();
+        expect(keys).toEqual([...QWERTY_30_KEYS].sort());
+      }
+    });
+  });
+
+  describe("プリセット id のユニーク性", () => {
+    it("全プリセットの id が重複しない", () => {
+      const presets = getPresets();
+      const ids = presets.map((p) => p.id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(ids.length);
+    });
+  });
+
+  describe("QWERTY プリセット", () => {
+    it("id が 'qwerty' のプリセットが存在する", () => {
+      const presets = getPresets();
+      const qwerty = presets.find((p) => p.id === "qwerty");
+      expect(qwerty).toBeDefined();
+    });
+
+    it("QWERTY プリセットの keymap はパススルー（各キーの値が自身のキーと同じ）である", () => {
+      const presets = getPresets();
+      const qwerty = presets.find((p) => p.id === "qwerty");
+      expect(qwerty).toBeDefined();
+      if (!qwerty) return;
+      for (const key of QWERTY_30_KEYS) {
+        expect(qwerty.keymap[key]).toBe(key);
+      }
+    });
+  });
+
+  describe("Colemak DH プリセット", () => {
+    it("id が 'colemak-dh' のプリセットが存在する", () => {
+      const presets = getPresets();
+      const colemakDh = presets.find((p) => p.id === "colemak-dh");
+      expect(colemakDh).toBeDefined();
+    });
+
+    it("Colemak DH プリセットの keymap が defaultCustomKeymap と一致する", () => {
+      const presets = getPresets();
+      const colemakDh = presets.find((p) => p.id === "colemak-dh");
+      expect(colemakDh).toBeDefined();
+      if (!colemakDh) return;
+      expect(colemakDh.keymap).toEqual(defaultCustomKeymap);
+    });
+  });
+
+  describe("Dvorak プリセット", () => {
+    it("id が 'dvorak' のプリセットが存在する", () => {
+      const presets = getPresets();
+      const dvorak = presets.find((p) => p.id === "dvorak");
+      expect(dvorak).toBeDefined();
+    });
+  });
+
+  describe("Colemak プリセット", () => {
+    it("id が 'colemak' のプリセットが存在する", () => {
+      const presets = getPresets();
+      const colemak = presets.find((p) => p.id === "colemak");
+      expect(colemak).toBeDefined();
+    });
+  });
+});

--- a/src/data/keybinding-presets.ts
+++ b/src/data/keybinding-presets.ts
@@ -1,0 +1,153 @@
+import type { KeybindingPreset } from "../types/keybinding";
+import { defaultCustomKeymap } from "./keymap";
+
+/** QWERTY 物理位置の 30 キー一覧 */
+const QWERTY_30_KEYS = [
+  "q",
+  "w",
+  "e",
+  "r",
+  "t",
+  "y",
+  "u",
+  "i",
+  "o",
+  "p",
+  "a",
+  "s",
+  "d",
+  "f",
+  "g",
+  "h",
+  "j",
+  "k",
+  "l",
+  ";",
+  "z",
+  "x",
+  "c",
+  "v",
+  "b",
+  "n",
+  "m",
+  ",",
+  ".",
+  "/",
+] as const;
+
+/** QWERTY パススルーキーマップ（各キーが自身にマップ） */
+const QWERTY_KEYMAP = Object.fromEntries(
+  QWERTY_30_KEYS.map((key) => [key, key]),
+) satisfies Record<string, string>;
+
+/**
+ * Dvorak 標準配列（QWERTY 物理位置 → Dvorak 出力文字）
+ *
+ * top:    q→', w→,, e→., r→p, t→y, y→f, u→g, i→c, o→r, p→l
+ * home:   a→a, s→o, d→e, f→u, g→i, h→d, j→h, k→t, l→n, ;→s
+ * bottom: z→;, x→q, c→j, v→k, b→x, n→b, m→m, ,→w, .→v, /→z
+ */
+const DVORAK_KEYMAP = {
+  q: "'",
+  w: ",",
+  e: ".",
+  r: "p",
+  t: "y",
+  y: "f",
+  u: "g",
+  i: "c",
+  o: "r",
+  p: "l",
+  a: "a",
+  s: "o",
+  d: "e",
+  f: "u",
+  g: "i",
+  h: "d",
+  j: "h",
+  k: "t",
+  l: "n",
+  ";": "s",
+  z: ";",
+  x: "q",
+  c: "j",
+  v: "k",
+  b: "x",
+  n: "b",
+  m: "m",
+  ",": "w",
+  ".": "v",
+  "/": "z",
+} satisfies Record<string, string>;
+
+/**
+ * Colemak（無印）標準配列（QWERTY 物理位置 → Colemak 出力文字）
+ *
+ * top:    q→q, w→w, e→f, r→p, t→g, y→j, u→l, i→u, o→y, p→;
+ * home:   a→a, s→r, d→s, f→t, g→d, h→h, j→n, k→e, l→i, ;→o
+ * bottom: z→z, x→x, c→c, v→v, b→b, n→k, m→m, ,→,, .→., /→/
+ */
+const COLEMAK_KEYMAP = {
+  q: "q",
+  w: "w",
+  e: "f",
+  r: "p",
+  t: "g",
+  y: "j",
+  u: "l",
+  i: "u",
+  o: "y",
+  p: ";",
+  a: "a",
+  s: "r",
+  d: "s",
+  f: "t",
+  g: "d",
+  h: "h",
+  j: "n",
+  k: "e",
+  l: "i",
+  ";": "o",
+  z: "z",
+  x: "x",
+  c: "c",
+  v: "v",
+  b: "b",
+  n: "k",
+  m: "m",
+  ",": ",",
+  ".": ".",
+  "/": "/",
+} satisfies Record<string, string>;
+
+const PRESETS: KeybindingPreset[] = [
+  {
+    id: "qwerty",
+    name: "QWERTY",
+    description: "標準 QWERTY 配列",
+    keymap: QWERTY_KEYMAP,
+  },
+  {
+    id: "colemak-dh",
+    name: "Colemak DH",
+    description: "Colemak DH 配列（デフォルトカスタムキーマップ）",
+    keymap: defaultCustomKeymap,
+  },
+  {
+    id: "dvorak",
+    name: "Dvorak",
+    description: "Dvorak 標準配列",
+    keymap: DVORAK_KEYMAP,
+  },
+  {
+    id: "colemak",
+    name: "Colemak",
+    description: "Colemak（無印）標準配列",
+    keymap: COLEMAK_KEYMAP,
+  },
+];
+
+/** 利用可能なキーボード配列プリセット一覧を返す */
+export function getPresets(): KeybindingPreset[] {
+  return PRESETS;
+}

--- a/src/types/keybinding.ts
+++ b/src/types/keybinding.ts
@@ -48,3 +48,14 @@ export interface KeybindingConfig {
 export function emptyBindings(): Record<VimMode, Keybinding[]> {
   return { n: [], v: [], x: [], o: [], i: [], s: [], c: [], t: [] };
 }
+
+/** プリセット配列の識別子 */
+export type PresetId = "qwerty" | "colemak-dh" | "dvorak" | "colemak";
+
+/** キーボード配列プリセット */
+export interface KeybindingPreset {
+  id: PresetId;
+  name: string;
+  description: string;
+  keymap: Record<string, string>;
+}


### PR DESCRIPTION
## Summary
- `KeybindingPreset` 型（`PresetId` union 付き）を `src/types/keybinding.ts` に追加
- QWERTY / Colemak DH / Dvorak / Colemak の 4 種プリセットを `src/data/keybinding-presets.ts` に定義
- `getPresets()` 関数でプリセット一覧を取得可能に

Closes #49

## Test plan
- [x] 全プリセットが 30 キー形式で QWERTY キーセットと一致
- [x] Colemak DH プリセットが既存 `defaultCustomKeymap` と一致
- [x] QWERTY プリセットがパススルー
- [x] プリセット ID がユニーク
- [x] Biome check / 全テスト (117) / ビルド 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)