### PR TITLE
feat: Practice/Reference モードのカスタムキーバインド対応

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,216 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { defaultCustomKeymap } from "./data/keymap";
+import type { KeybindingConfig } from "./types/keybinding";
+import { emptyBindings } from "./types/keybinding";
+
+// 子コンポーネントをモック化して渡された customKeymap props を検証する
+vi.mock("./components/PracticeMode/PracticeMode", () => ({
+  PracticeMode: vi.fn(
+    ({ customKeymap }: { customKeymap: Record<string, string> }) => (
+      <div
+        data-testid="practice-mode"
+        data-custom-keymap={JSON.stringify(customKeymap)}
+      />
+    ),
+  ),
+}));
+
+vi.mock("./components/CommandReference/CommandReference", () => ({
+  CommandReference: vi.fn(
+    ({ customKeymap }: { customKeymap: Record<string, string> }) => (
+      <div
+        data-testid="command-reference"
+        data-custom-keymap={JSON.stringify(customKeymap)}
+      />
+    ),
+  ),
+}));
+
+vi.mock("./components/Keyboard/Keyboard", () => ({
+  Keyboard: vi.fn(
+    ({ customKeymap }: { customKeymap: Record<string, string> }) => (
+      <div
+        data-testid="keyboard"
+        data-custom-keymap={JSON.stringify(customKeymap)}
+      />
+    ),
+  ),
+}));
+
+// useKeyboardLayout をモック化してファイルシステムアクセスを回避する
+vi.mock("./hooks/useKeyboardLayout", () => ({
+  useKeyboardLayout: vi.fn(() => ({
+    layout: { name: "ANSI 60%", keys: [] },
+    loadFromJSON: vi.fn(),
+    error: null,
+  })),
+}));
+
+// useNvimMaps をモック化してネットワークアクセスを回避する
+vi.mock("./hooks/useNvimMaps", () => ({
+  useNvimMaps: vi.fn(() => ({
+    nvimMaps: null,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  })),
+}));
+
+// storage をモック化して localStorage アクセスを回避する
+vi.mock("./utils/storage", () => ({
+  loadKeymap: vi.fn(() => null),
+  saveKeymap: vi.fn(),
+  saveLayout: vi.fn(),
+  clearAllStorage: vi.fn(),
+}));
+
+// AppContent を直接テストするためにインポートする
+// App はプロバイダーを内包するため、テストでは KeybindingProvider に initial を渡す形で構成する
+import { App } from "./App";
+import { CommandReference } from "./components/CommandReference/CommandReference";
+import { Keyboard } from "./components/Keyboard/Keyboard";
+import { PracticeMode } from "./components/PracticeMode/PracticeMode";
+
+const mockedPracticeMode = vi.mocked(PracticeMode);
+const mockedCommandReference = vi.mocked(CommandReference);
+const mockedKeyboard = vi.mocked(Keyboard);
+
+function buildConfig(customKeymap?: Record<string, string>): KeybindingConfig {
+  const now = new Date().toISOString();
+  return {
+    name: "test-config",
+    bindings: emptyBindings(),
+    customKeymap,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+/**
+ * KeybindingProvider の initial prop で customKeymap を注入し、
+ * AppContent 相当の動作をテストするラッパーコンポーネント。
+ *
+ * App は内部で KeybindingProvider を持つため直接 initial を渡せない。
+ * そのため、AppContent を単独でレンダーし KeybindingProvider で包む構成を使う。
+ */
+function renderAppContent(config: KeybindingConfig) {
+  // AppContent は export されていないため、App の代わりに
+  // KeybindingProvider + AppContent の構成を再現するアプローチを取る。
+  // ただし AppContent は非公開なので、App 全体をレンダーした上で
+  // KeybindingProvider の initial を外側から差し込む方法は使えない。
+  //
+  // 代替として: AppContent 相当のロジックのみを持つテスト用コンポーネントを作るか、
+  // App を export してその KeybindingProvider に initial を渡す改修を待つ。
+  //
+  // 現状の App は KeybindingProvider を内包しているため、
+  // このテストは App を initial 対応にする実装変更が完了した後にパスすることを期待する。
+  // (test-later パターン: 実装前にテストを書く)
+  //
+  // NOTE: 現時点では App の KeybindingProvider に initial を渡す手段がないため、
+  //       テストは失敗する。実装で App を以下のように変更することでパスする:
+  //   export function App({ initial }: { initial?: KeybindingConfig }) {
+  //     return <KeybindingProvider initial={initial}><AppContent /></KeybindingProvider>;
+  //   }
+  return render(<App initial={config} />);
+}
+
+describe("AppContent - customKeymap の反映", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("デフォルトフォールバック", () => {
+    test("customKeymap が undefined の場合、Keyboard に defaultCustomKeymap が渡される", async () => {
+      const config = buildConfig(undefined);
+
+      renderAppContent(config);
+
+      const calls = mockedKeyboard.mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[0].customKeymap).toEqual(defaultCustomKeymap);
+    });
+
+    test("customKeymap が undefined の場合、練習モードに切り替えると PracticeMode に defaultCustomKeymap が渡される", async () => {
+      const user = userEvent.setup();
+      const config = buildConfig(undefined);
+
+      renderAppContent(config);
+
+      await user.click(screen.getByRole("button", { name: "練習" }));
+
+      const calls = mockedPracticeMode.mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[0].customKeymap).toEqual(defaultCustomKeymap);
+    });
+
+    test("customKeymap が undefined の場合、辞書モードに切り替えると CommandReference に defaultCustomKeymap が渡される", async () => {
+      const user = userEvent.setup();
+      const config = buildConfig(undefined);
+
+      renderAppContent(config);
+
+      await user.click(screen.getByRole("button", { name: "辞書" }));
+
+      const calls = mockedCommandReference.mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[0].customKeymap).toEqual(defaultCustomKeymap);
+    });
+  });
+
+  describe("Context からの customKeymap 反映", () => {
+    test("customKeymap が設定されている場合、Keyboard にその値が渡される", async () => {
+      const customKeymap = { a: "x", s: "y", d: "z" };
+      const config = buildConfig(customKeymap);
+
+      renderAppContent(config);
+
+      const calls = mockedKeyboard.mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[0].customKeymap).toEqual(customKeymap);
+    });
+
+    test("customKeymap が設定されている場合、defaultCustomKeymap とは異なる値が使われる", async () => {
+      const customKeymap = { a: "x", s: "y", d: "z" };
+      const config = buildConfig(customKeymap);
+
+      renderAppContent(config);
+
+      const calls = mockedKeyboard.mock.calls;
+      const lastCall = calls[calls.length - 1];
+      const passedKeymap = lastCall[0].customKeymap;
+
+      expect(passedKeymap).toEqual(customKeymap);
+      expect(passedKeymap).not.toEqual(defaultCustomKeymap);
+    });
+
+    test("customKeymap が設定されている場合、練習モードで PracticeMode にその値が渡される", async () => {
+      const user = userEvent.setup();
+      const customKeymap = { a: "x", s: "y", d: "z" };
+      const config = buildConfig(customKeymap);
+
+      renderAppContent(config);
+
+      await user.click(screen.getByRole("button", { name: "練習" }));
+
+      const calls = mockedPracticeMode.mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[0].customKeymap).toEqual(customKeymap);
+    });
+
+    test("customKeymap が設定されている場合、辞書モードで CommandReference にその値が渡される", async () => {
+      const user = userEvent.setup();
+      const customKeymap = { a: "x", s: "y", d: "z" };
+      const config = buildConfig(customKeymap);
+
+      renderAppContent(config);
+
+      await user.click(screen.getByRole("button", { name: "辞書" }));
+
+      const calls = mockedCommandReference.mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[0].customKeymap).toEqual(customKeymap);
+    });
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,10 @@ import { Keyboard } from "./components/Keyboard/Keyboard";
 import { LayoutLoader } from "./components/LayoutLoader/LayoutLoader";
 import { ModeSelector } from "./components/ModeSelector/ModeSelector";
 import { PracticeMode } from "./components/PracticeMode/PracticeMode";
-import { KeybindingProvider } from "./context/KeybindingContext";
+import {
+  KeybindingProvider,
+  useKeybindingContext,
+} from "./context/KeybindingContext";
 import defaultLayoutJSON from "./data/default-layout.json";
 import { defaultCustomKeymap } from "./data/keymap";
 import {
@@ -16,7 +19,7 @@ import {
 } from "./data/vim-commands";
 import { useKeyboardLayout } from "./hooks/useKeyboardLayout";
 import { useNvimMaps } from "./hooks/useNvimMaps";
-import type { VimMode } from "./types/keybinding";
+import type { KeybindingConfig, VimMode } from "./types/keybinding";
 import type { HighlightEntry, VIAKeymapFull, VimCommand } from "./types/vim";
 import { mergeWithNvimMaps } from "./utils/merge-vim-commands";
 import {
@@ -30,7 +33,15 @@ import { parseVIAKeymap, parseVIAKeymapFull } from "./utils/via-keymap-parser";
 const CORNE_V4_MATRIX_COLS = 7;
 const KEYMAP_LOADED_LABEL = "keymap loaded";
 
-export function App() {
+function AppContent() {
+  const { config } = useKeybindingContext();
+
+  // Context の customKeymap を優先し、未設定の場合はデフォルトにフォールバック
+  const customKeymap = useMemo(
+    () => config.customKeymap ?? defaultCustomKeymap,
+    [config.customKeymap],
+  );
+
   const { layout, loadFromJSON, error } = useKeyboardLayout();
   const [hoveredCommand, setHoveredCommand] = useState<VimCommand | null>(null);
   const [hoveredCustomKey, setHoveredCustomKey] = useState<string | null>(null);
@@ -134,7 +145,7 @@ export function App() {
   const noopHover = useCallback(() => {}, []);
 
   return (
-    <KeybindingProvider>
+    <>
       <header className={styles.header}>
         <div className={styles.headerTop}>
           <div>
@@ -213,7 +224,7 @@ export function App() {
       {mode === "practice" && (
         <div className={styles.practice}>
           <PracticeMode
-            customKeymap={defaultCustomKeymap}
+            customKeymap={customKeymap}
             viaKeymapFull={viaKeymapFull}
             onHighlightKeys={handleHighlightKeys}
           />
@@ -225,7 +236,7 @@ export function App() {
       >
         <Keyboard
           layout={layout}
-          customKeymap={defaultCustomKeymap}
+          customKeymap={customKeymap}
           matrixKeymap={matrixKeymap}
           onHover={mode === "visualize" ? handleHover : noopHover}
           highlightKeys={
@@ -241,7 +252,7 @@ export function App() {
       {mode === "reference" && (
         <div className={styles.reference}>
           <CommandReference
-            customKeymap={defaultCustomKeymap}
+            customKeymap={customKeymap}
             viaKeymapFull={viaKeymapFull}
             onHighlightKeys={handleHighlightKeys}
             mergedCommands={mergedCommands}
@@ -270,6 +281,14 @@ export function App() {
           </div>
         ))}
       </div>
+    </>
+  );
+}
+
+export function App({ initial }: { initial?: KeybindingConfig }) {
+  return (
+    <KeybindingProvider initial={initial}>
+      <AppContent />
     </KeybindingProvider>
   );
 }


### PR DESCRIPTION
## Summary
- `App` の JSX を `AppContent` コンポーネントに抽出し、`useKeybindingContext()` で `config.customKeymap` を取得
- `config.customKeymap ?? defaultCustomKeymap` でフォールバック付きの customKeymap を `PracticeMode`・`CommandReference`・`Keyboard` に渡すよう変更
- `App` に `initial` prop を追加し、テストから `KeybindingProvider` に設定を注入可能に

## Test plan
- [x] customKeymap 未設定時に defaultCustomKeymap にフォールバックすること（3 テスト）
- [x] customKeymap 設定時に各コンポーネントにその値が渡ること（4 テスト）
- [x] Biome check PASS
- [x] 全 112 テスト PASS
- [x] Build PASS

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)