### PR TITLE
fix: PRレビューコメントを日本語で出力するよう修正

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -86,7 +86,9 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
+          prompt: |
+            日本語でレビューコメントを出力してください。
+            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment
           claude_args: '--allowedTools "Bash(gh pr diff:*)" --allowedTools "Bash(gh pr view:*)" --allowedTools "Bash(git diff:*)" --allowedTools "Bash(gh issue view:*)" --allowedTools "Bash(gh search:*)" --allowedTools "Bash(gh issue list:*)" --allowedTools "Bash(gh pr comment:*)" --allowedTools "Bash(gh pr list:*)" --allowedTools "mcp__github_inline_comment__create_inline_comment"'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary
- Claude Code Action の `prompt` パラメータに「日本語でレビューコメントを出力してください。」の指示を追加
- マルチライン YAML (`|`) でコマンドと言語指示を分離し、既存動作に影響を与えない構成

Closes #59

## Test plan
- [ ] PR を作成し、レビューコメントが日本語で投稿されることを確認
- [ ] 既存のワークフロー動作（差分取得、コメント投稿、outdated thread resolve）に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)