### PR TITLE
fix: local-ci の sub agent が Bash 権限を取得できない (#31)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm lint)",
+      "Bash(pnpm lint:*)",
+      "Bash(pnpm test)",
+      "Bash(pnpm test:*)",
+      "Bash(pnpm build)",
+      "Bash(pnpm exec:*)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- プロジェクト共通の Bash 許可パターン (`pnpm lint`, `pnpm test`, `pnpm build`) を tracked な `.claude/settings.json` に配置
- `settings.local.json`（gitignore 対象）にあった共通パターンを移動し、旧ワークフロー用パターンを削除

## 背景
`local-ci` の sub agent がバックグラウンドで `pnpm lint` / `pnpm test` / `pnpm build` を実行する際、`settings.local.json` の許可パターンと不一致（`pnpm lint:*` はマッチするが `pnpm lint` はマッチしない）で権限エラーが発生していた。

Closes #31

## Test plan
- [ ] `/local-ci` 実行時に 3 つの sub agent 全てがバックグラウンドで正常に動作する
- [ ] `pnpm lint`, `pnpm test`, `pnpm build` が許可パターンに含まれている
- [ ] 旧ラベルワークフローの許可パターンが削除されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)