### PR TITLE
feat: Lua/JSON エクスポート変換ロジック (#50)

### DIFF
--- a/src/utils/keybinding-exporters.test.ts
+++ b/src/utils/keybinding-exporters.test.ts
@@ -126,7 +126,7 @@ describe("keybindingToLua", () => {
       expect(result).toContain("{ noremap = true }");
     });
 
-    it("noremap: false の場合は { noremap = true } オプションを付けない", () => {
+    it("noremap: false の場合は { noremap = false } オプションを付与する", () => {
       const config = makeConfig({
         bindings: {
           ...emptyBindings(),
@@ -136,7 +136,7 @@ describe("keybindingToLua", () => {
 
       const result = keybindingToLua(config);
 
-      expect(result).not.toContain("{ noremap = true }");
+      expect(result).toContain("{ noremap = false }");
     });
   });
 
@@ -167,7 +167,7 @@ describe("keybindingToLua", () => {
       expect(result).toContain('"t"');
     });
 
-    it("バインディングが空のモードは出力されない（または空行にならない）", () => {
+    it("バインディングが空のモードは出力されない", () => {
       const config = makeConfig({
         bindings: {
           ...emptyBindings(),
@@ -177,9 +177,8 @@ describe("keybindingToLua", () => {
 
       const result = keybindingToLua(config);
 
-      // n モードのバインディングは存在する
-      expect(result).toContain('"n"');
-      // 空モードは vim.keymap.set を生成しない
+      expect(result).toContain("-- n mode");
+      expect(result).not.toContain("-- v mode");
       const lines = result
         .split("\n")
         .filter((line) => line.includes('vim.keymap.set("v"'));

--- a/src/utils/keybinding-exporters.ts
+++ b/src/utils/keybinding-exporters.ts
@@ -13,16 +13,18 @@ export function keybindingToLua(config: KeybindingConfig): string {
     const bindings = config.bindings[mode];
     if (bindings.length === 0) continue;
 
+    lines.push(`-- ${mode} mode`);
     for (const binding of bindings) {
       const rhs = binding.rhs ?? binding.commandId;
       if (!rhs) continue;
       const lhsEscaped = escapeLua(binding.lhs);
       const rhsEscaped = escapeLua(rhs);
-      const opts = binding.noremap ? ", { noremap = true }" : "";
+      const noremapVal = binding.noremap ? "true" : "false";
       lines.push(
-        `vim.keymap.set("${mode}", "${lhsEscaped}", "${rhsEscaped}"${opts})`,
+        `vim.keymap.set("${mode}", "${lhsEscaped}", "${rhsEscaped}", { noremap = ${noremapVal} })`,
       );
     }
+    lines.push("");
   }
 
   return lines.join("\n");


### PR DESCRIPTION
## Summary
- `keybindingToLua()`: KeybindingConfig を `vim.keymap.set()` 形式の Lua スクリプトに変換
- `keybindingToJSON()`: KeybindingConfig を整形済み JSON 文字列に変換
- 29件の単体テストを追加

Closes #50

## Test plan
- [x] keybindingToLua: 全 VimMode のバインディング変換（21件）
- [x] keybindingToJSON: フィールド保持・valid JSON 確認（8件）
- [x] 特殊キー・複合キーシーケンス・Lua エスケープ処理
- [x] Biome check / Build 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)