### PR TITLE
feat: GitHub Pages デプロイを設定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,48 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '.claude/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '**/*.md'
+      - 'LICENSE'
+      - '.gitignore'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vite";
 import { nvimPlugin } from "./vite-plugin-nvim";
 
 export default defineConfig({
+  base: "/keyviz/",
   plugins: [react(), nvimPlugin()],
   test: {
     environment: "jsdom",


### PR DESCRIPTION
## Summary
- `vite.config.ts` に `base: "/keyviz/"` を追加し、GitHub Pages の URL パスに対応
- `.github/workflows/deploy.yml` を新規作成（main push → pnpm build → Pages デプロイ）
- permissions を最小権限原則に基づきジョブスコープで設定
- ci.yml と整合する `paths-ignore` を設定

Closes #68

## Test plan
- [ ] CI（lint / test / build）が通ること
- [ ] リポジトリ Settings > Pages で Source を「GitHub Actions」に設定
- [ ] main マージ後に `https://shiroinock.github.io/keyviz/` でアプリが表示されること
- [ ] 静的アセット（favicon.svg, icons.svg）が正しく読み込まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)