### PR TITLE
chore: .gitignore に .pnpm-store と .claude/worktrees を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# pnpm
+.pnpm-store
+
+# Claude Code worktrees
+.claude/worktrees


### PR DESCRIPTION
## Summary
- worktree セッションで生成される `.pnpm-store` と `.claude/worktrees/` を `.gitignore` に追加
- worktree 内で `pnpm install` 実行時にプロジェクトルートに `.pnpm-store` が作られる問題の暫定対応
- 根本対応は #92 で WorktreeCreate フックによる node_modules symlink を検討

## Test plan
- [ ] `git status` で `.pnpm-store` と `.claude/worktrees` が untracked に出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)