### PR TITLE
feat: IMPORT_NVIM アクション実装

### DIFF
--- a/src/hooks/useKeybindingConfig.test.ts
+++ b/src/hooks/useKeybindingConfig.test.ts
@@ -5,6 +5,7 @@ vi.mock("../utils/storage", () => ({
   saveKeybindingConfig: vi.fn(),
 }));
 
+import type { NvimMapping } from "../types/vim";
 import { saveKeybindingConfig } from "../utils/storage";
 import { useKeybindingConfig } from "./useKeybindingConfig";
 
@@ -132,6 +133,109 @@ describe("useKeybindingConfig — localStorage 永続化", () => {
       );
       expect(hasAa).toBe(true);
       expect(hasBb).toBe(true);
+    });
+  });
+});
+
+// ── テストヘルパー ──
+
+function makeNvimMap(overrides: Partial<NvimMapping> = {}): NvimMapping {
+  return {
+    mode: "n",
+    lhs: "j",
+    rhs: "j",
+    noremap: true,
+    description: "",
+    source: "user",
+    sourceDetail: "",
+    ...overrides,
+  };
+}
+
+describe("useKeybindingConfig — IMPORT_NVIM", () => {
+  describe("state.bindings の更新", () => {
+    it("IMPORT_NVIM dispatch 後に state.bindings が空でなくなる", () => {
+      const { result } = renderHook(() => useKeybindingConfig());
+      const maps: NvimMapping[] = [
+        makeNvimMap({ mode: "n", lhs: "j", description: "下に移動" }),
+      ];
+
+      act(() => {
+        result.current.dispatch({ type: "IMPORT_NVIM", maps });
+      });
+
+      const totalBindings = Object.values(
+        result.current.config.bindings,
+      ).reduce((sum, arr) => sum + arr.length, 0);
+      expect(totalBindings).toBeGreaterThan(0);
+    });
+
+    it("ノーマルモードのマップが state.bindings.n に反映される", () => {
+      const { result } = renderHook(() => useKeybindingConfig());
+      const maps: NvimMapping[] = [
+        makeNvimMap({ mode: "n", lhs: "j", description: "下に移動" }),
+      ];
+
+      act(() => {
+        result.current.dispatch({ type: "IMPORT_NVIM", maps });
+      });
+
+      const nBindings = result.current.config.bindings.n;
+      const found = nBindings.find((b) => b.lhs === "j");
+      expect(found).toBeDefined();
+    });
+
+    it("v モードのマップが state.bindings.v、x、s にそれぞれ反映される", () => {
+      const { result } = renderHook(() => useKeybindingConfig());
+      const maps: NvimMapping[] = [
+        makeNvimMap({ mode: "v", lhs: "gq", description: "ビジュアル整形" }),
+      ];
+
+      act(() => {
+        result.current.dispatch({ type: "IMPORT_NVIM", maps });
+      });
+
+      const bindings = result.current.config.bindings;
+      expect(bindings.v.find((b) => b.lhs === "gq")).toBeDefined();
+      expect(bindings.x.find((b) => b.lhs === "gq")).toBeDefined();
+      expect(bindings.s.find((b) => b.lhs === "gq")).toBeDefined();
+    });
+  });
+
+  describe("永続化", () => {
+    it("IMPORT_NVIM dispatch 後に saveKeybindingConfig が呼ばれる", () => {
+      const { result } = renderHook(() => useKeybindingConfig());
+      const maps: NvimMapping[] = [
+        makeNvimMap({ mode: "n", lhs: "k", description: "上に移動" }),
+      ];
+
+      act(() => {
+        result.current.dispatch({ type: "IMPORT_NVIM", maps });
+      });
+
+      expect(mockSaveKeybindingConfig).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("updatedAt の更新", () => {
+    it("IMPORT_NVIM dispatch 後に updatedAt が更新される", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+      const { result } = renderHook(() => useKeybindingConfig());
+      const before = result.current.config.updatedAt;
+
+      vi.setSystemTime(new Date("2026-01-01T00:00:01.000Z"));
+      const maps: NvimMapping[] = [
+        makeNvimMap({ mode: "n", lhs: "l", description: "右に移動" }),
+      ];
+
+      act(() => {
+        result.current.dispatch({ type: "IMPORT_NVIM", maps });
+      });
+
+      expect(result.current.config.updatedAt).not.toBe(before);
+      vi.useRealTimers();
     });
   });
 });

--- a/src/hooks/useKeybindingConfig.ts
+++ b/src/hooks/useKeybindingConfig.ts
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
+import { vimCommands } from "../data/vim-commands";
 import type {
   Keybinding,
   KeybindingConfig,
   VimMode,
 } from "../types/keybinding";
 import type { NvimMapping } from "../types/vim";
+import { convertNvimMapsToKeybindings } from "../utils/convert-nvim-to-keybinding";
 import { createDefaultConfig } from "../utils/keybinding-defaults";
 import { saveKeybindingConfig } from "../utils/storage";
 
@@ -93,8 +95,12 @@ function keybindingReducer(
     }
 
     case "IMPORT_NVIM": {
-      // Phase 4 で実装
-      return state;
+      const imported = convertNvimMapsToKeybindings(action.maps, vimCommands);
+      return {
+        ...state,
+        bindings: imported,
+        updatedAt: now,
+      };
     }
 
     case "RESET_TO_DEFAULTS":

--- a/src/utils/convert-nvim-to-keybinding.test.ts
+++ b/src/utils/convert-nvim-to-keybinding.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it } from "vitest";
+import type { VimMode } from "../types/keybinding";
+import type { NvimMapping, VimCommand } from "../types/vim";
+import { convertNvimMapsToKeybindings } from "./convert-nvim-to-keybinding";
+
+const baseVimCommands: VimCommand[] = [
+  { key: "j", name: "↓", description: "下に移動", category: "motion" },
+  { key: "k", name: "↑", description: "上に移動", category: "motion" },
+  { key: "dd", name: "行削除", description: "行を削除", category: "edit" },
+];
+
+function makeNvimMap(
+  overrides: Partial<NvimMapping> & { lhs: string },
+): NvimMapping {
+  return {
+    mode: "n",
+    rhs: "",
+    noremap: true,
+    description: overrides.description ?? "test",
+    source: "user",
+    sourceDetail: "init.lua",
+    ...overrides,
+  };
+}
+
+describe("convertNvimMapsToKeybindings", () => {
+  describe("空入力", () => {
+    it("空の maps を渡すと全モードが空配列の Record を返す", () => {
+      const result = convertNvimMapsToKeybindings([], baseVimCommands);
+
+      const modes: VimMode[] = ["n", "v", "x", "o", "i", "s", "c", "t"];
+      for (const mode of modes) {
+        expect(result[mode]).toEqual([]);
+      }
+    });
+  });
+
+  describe("ノーマルモードの変換", () => {
+    it("ノーマルモード (n) のマップが Keybinding に変換される", () => {
+      const maps = [
+        makeNvimMap({
+          lhs: "gd",
+          rhs: "vim.lsp.buf.definition()",
+          mode: "n",
+          description: "Go to definition",
+        }),
+      ];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.n).toHaveLength(1);
+      expect(result.n[0].lhs).toBe("gd");
+    });
+  });
+
+  describe("VimCommand マッチ", () => {
+    it("VimCommand にマッチするマップは commandId が VimCommand.key に設定される", () => {
+      const maps = [makeNvimMap({ lhs: "j", mode: "n" })];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.n[0].commandId).toBe("j");
+    });
+
+    it("VimCommand にマッチするマップは name が VimCommand から設定される", () => {
+      const maps = [makeNvimMap({ lhs: "j", mode: "n" })];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.n[0].name).toBe("↓");
+    });
+
+    it("VimCommand にマッチするマップは description が VimCommand から設定される", () => {
+      const maps = [makeNvimMap({ lhs: "j", mode: "n" })];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.n[0].description).toBe("下に移動");
+    });
+
+    it("VimCommand にマッチするマップは category が VimCommand から設定される", () => {
+      const maps = [makeNvimMap({ lhs: "j", mode: "n" })];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.n[0].category).toBe("motion");
+    });
+  });
+
+  describe("VimCommand 非マッチ", () => {
+    it("VimCommand にマッチしないマップは rhs を保持する", () => {
+      const maps = [
+        makeNvimMap({ lhs: "gd", rhs: "vim.lsp.buf.definition()", mode: "n" }),
+      ];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.n[0].rhs).toBe("vim.lsp.buf.definition()");
+    });
+
+    it("VimCommand にマッチしないマップは name が lhs になる", () => {
+      const maps = [makeNvimMap({ lhs: "gd", mode: "n" })];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.n[0].name).toBe("gd");
+    });
+
+    it("VimCommand にマッチしないマップは category が 'misc' になる", () => {
+      const maps = [makeNvimMap({ lhs: "gd", mode: "n" })];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.n[0].category).toBe("misc");
+    });
+
+    it("VimCommand にマッチしないマップは commandId が設定されない", () => {
+      const maps = [makeNvimMap({ lhs: "gd", mode: "n" })];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.n[0].commandId).toBeUndefined();
+    });
+  });
+
+  describe("source フィールド", () => {
+    it("VimCommand にマッチするマップの source が 'nvim-import' になる", () => {
+      const maps = [makeNvimMap({ lhs: "j", mode: "n" })];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.n[0].source).toBe("nvim-import");
+    });
+
+    it("VimCommand にマッチしないマップの source が 'nvim-import' になる", () => {
+      const maps = [makeNvimMap({ lhs: "gd", mode: "n" })];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.n[0].source).toBe("nvim-import");
+    });
+
+    it("複数マップの全バインディングの source が 'nvim-import' になる", () => {
+      const maps = [
+        makeNvimMap({ lhs: "j", mode: "n" }),
+        makeNvimMap({ lhs: "k", mode: "n" }),
+        makeNvimMap({ lhs: "gd", mode: "n" }),
+      ];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.n.every((b) => b.source === "nvim-import")).toBe(true);
+    });
+  });
+
+  describe("noremap の引き継ぎ", () => {
+    it("noremap: true のマップは Keybinding の noremap が true になる", () => {
+      const maps = [makeNvimMap({ lhs: "j", noremap: true, mode: "n" })];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.n[0].noremap).toBe(true);
+    });
+
+    it("noremap: false のマップは Keybinding の noremap が false になる", () => {
+      const maps = [makeNvimMap({ lhs: "gd", noremap: false, mode: "n" })];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.n[0].noremap).toBe(false);
+    });
+  });
+
+  describe("expandNvimMapMode によるモード展開", () => {
+    it("'v' モードのマップが v, x, s の各モードに分配される", () => {
+      const maps = [makeNvimMap({ lhs: "gv", mode: "v" })];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.v).toHaveLength(1);
+      expect(result.x).toHaveLength(1);
+      expect(result.s).toHaveLength(1);
+      expect(result.n).toHaveLength(0);
+    });
+
+    it("'v' モードで展開された各モードのバインディングが同じ lhs を持つ", () => {
+      const maps = [makeNvimMap({ lhs: "gv", mode: "v" })];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.v[0].lhs).toBe("gv");
+      expect(result.x[0].lhs).toBe("gv");
+      expect(result.s[0].lhs).toBe("gv");
+    });
+
+    it("'!' モードのマップが i, c の各モードに分配される", () => {
+      const maps = [makeNvimMap({ lhs: "jk", mode: "!" })];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.i).toHaveLength(1);
+      expect(result.c).toHaveLength(1);
+      expect(result.n).toHaveLength(0);
+    });
+
+    it("'' モードのマップが n, v, x, o の各モードに分配される", () => {
+      const maps = [makeNvimMap({ lhs: "gf", mode: "" })];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.n).toHaveLength(1);
+      expect(result.v).toHaveLength(1);
+      expect(result.x).toHaveLength(1);
+      expect(result.o).toHaveLength(1);
+      expect(result.i).toHaveLength(0);
+    });
+
+    it("'x' モードのマップは x のみに分配される", () => {
+      const maps = [makeNvimMap({ lhs: "gv", mode: "x" })];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.x).toHaveLength(1);
+      expect(result.v).toHaveLength(0);
+      expect(result.s).toHaveLength(0);
+      expect(result.n).toHaveLength(0);
+    });
+  });
+
+  describe("<Plug> スキップ", () => {
+    it("<Plug> で始まる lhs はスキップされる", () => {
+      const maps = [makeNvimMap({ lhs: "<Plug>(something)", mode: "n" })];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.n).toHaveLength(0);
+    });
+
+    it("<Plug> で始まる lhs は全モードでスキップされる", () => {
+      const maps = [makeNvimMap({ lhs: "<Plug>(visual-op)", mode: "v" })];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.v).toHaveLength(0);
+      expect(result.x).toHaveLength(0);
+      expect(result.s).toHaveLength(0);
+    });
+
+    it("<Plug> 以外のマップは通常通り変換される", () => {
+      const maps = [
+        makeNvimMap({ lhs: "<Plug>(something)", mode: "n" }),
+        makeNvimMap({ lhs: "gd", mode: "n" }),
+      ];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.n).toHaveLength(1);
+      expect(result.n[0].lhs).toBe("gd");
+    });
+  });
+
+  describe("複合ケース", () => {
+    it("マッチするマップとマッチしないマップが混在する場合に両方変換される", () => {
+      const maps = [
+        makeNvimMap({ lhs: "j", mode: "n" }),
+        makeNvimMap({ lhs: "gd", rhs: "definition", mode: "n" }),
+      ];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.n).toHaveLength(2);
+
+      const matchedBinding = result.n.find((b) => b.lhs === "j");
+      expect(matchedBinding?.commandId).toBe("j");
+      expect(matchedBinding?.name).toBe("↓");
+
+      const unmatchedBinding = result.n.find((b) => b.lhs === "gd");
+      expect(unmatchedBinding?.commandId).toBeUndefined();
+      expect(unmatchedBinding?.name).toBe("gd");
+      expect(unmatchedBinding?.rhs).toBe("definition");
+    });
+
+    it("異なるモードの複数マップが正しく分配される", () => {
+      const maps = [
+        makeNvimMap({ lhs: "j", mode: "n" }),
+        makeNvimMap({ lhs: "k", mode: "x" }),
+        makeNvimMap({ lhs: "dd", mode: "!" }),
+      ];
+      const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
+
+      expect(result.n).toHaveLength(1);
+      expect(result.n[0].lhs).toBe("j");
+
+      expect(result.x).toHaveLength(1);
+      expect(result.x[0].lhs).toBe("k");
+
+      expect(result.i).toHaveLength(1);
+      expect(result.i[0].lhs).toBe("dd");
+
+      expect(result.c).toHaveLength(1);
+      expect(result.c[0].lhs).toBe("dd");
+    });
+  });
+});

--- a/src/utils/convert-nvim-to-keybinding.ts
+++ b/src/utils/convert-nvim-to-keybinding.ts
@@ -1,0 +1,44 @@
+import type { Keybinding, VimMode } from "../types/keybinding";
+import { emptyBindings } from "../types/keybinding";
+import type { NvimMapping, VimCommand } from "../types/vim";
+import { expandNvimMapMode } from "../types/vim";
+
+export function convertNvimMapsToKeybindings(
+  maps: NvimMapping[],
+  vimCommands: VimCommand[],
+): Record<VimMode, Keybinding[]> {
+  const result = emptyBindings();
+  const cmdByKey = new Map(vimCommands.map((c) => [c.key, c]));
+
+  for (const map of maps) {
+    if (map.lhs.startsWith("<Plug>")) continue;
+
+    const matched = cmdByKey.get(map.lhs);
+
+    const binding: Keybinding = matched
+      ? {
+          lhs: map.lhs,
+          commandId: matched.key,
+          name: matched.name,
+          description: matched.description,
+          category: matched.category,
+          source: "nvim-import",
+          noremap: map.noremap,
+        }
+      : {
+          lhs: map.lhs,
+          rhs: map.rhs,
+          name: map.lhs,
+          description: map.description,
+          category: "misc",
+          source: "nvim-import",
+          noremap: map.noremap,
+        };
+
+    for (const mode of expandNvimMapMode(map.mode)) {
+      result[mode].push(binding);
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- `convertNvimMapsToKeybindings` 関数を新規作成: NvimMapping[] を VimMode 別 Keybinding[] に変換
- `useKeybindingConfig` の IMPORT_NVIM reducer case をスタブから実装に置き換え
- VimCommand マッチ時は commandId/name/description/category を設定、非マッチ時は rhs を保持

## Test plan
- [x] `convert-nvim-to-keybinding.test.ts` — 25 tests (空入力, マッチ/非マッチ, source, noremap, モード展開, Plug スキップ, 複合ケース)
- [x] `useKeybindingConfig.test.ts` — 5 tests (bindings 更新, モード展開, 永続化, updatedAt)
- [x] local-ci: Biome check / Test (331 passed) / Build — 全て PASS

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)