### PR TITLE
fix: build ジョブに Pages API パーミッションを追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary
- `deploy.yml` の build ジョブに `pages: write` / `id-token: write` パーミッションを追加
- `actions/configure-pages@v5` が Pages API にアクセスできるようにする

## 背景
トップレベルの `permissions` が `contents: read` のみのため、build ジョブの `configure-pages` ステップが Pages API にアクセスできず毎回失敗していた。

## 補足
リポジトリ Settings → Pages → Source を「GitHub Actions」に設定する手動対応も必要（未設定の場合）。

Closes #102

## Test plan
- [ ] main マージ後に Deploy ワークフローが成功すること
- [ ] GitHub Pages にサイトが公開されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)