### PR TITLE
feat: Deploy ワークフローに品質ゲートを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+# NOTE: deploy.yml の workflow_run トリガーがこの name を参照している
 name: CI
 
 on:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,10 @@
 name: Deploy
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
     branches: [main]
-    paths-ignore:
-      - '.claude/**'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '**/*.md'
-      - 'LICENSE'
-      - '.gitignore'
 
 permissions:
   contents: read
@@ -19,6 +15,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- deploy.yml のトリガーを `on: push` から `on: workflow_run` に変更し、CI 成功時のみデプロイを実行
- build ジョブに `if: github.event.workflow_run.conclusion == 'success'` 条件を追加
- ci.yml にワークフロー名の依存関係を示すコメントを追加

Closes #88

## Test plan
- [ ] CI が全て成功した場合にデプロイが実行されることを確認
- [ ] CI が失敗した場合にデプロイがスキップされることを確認
- [ ] ドキュメントのみの変更（paths-ignore 対象）でデプロイが実行されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)