### PR TITLE
fix: Biome の .claude 除外設定を追加

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,7 @@
     "useIgnoreFile": true
   },
   "files": {
-    "includes": ["**", "!!**/dist"]
+    "includes": ["**", "!!.claude", "!!**/dist"]
   },
   "formatter": {
     "enabled": true,


### PR DESCRIPTION
## Summary
- `biome.json` の `files.includes` に `\!\!.claude` を追加し、`.claude/` ディレクトリを Biome のチェック対象から除外
- `.claude/settings.local.json` での warning と format の競合を解消

Closes #112

## Test plan
- [x] `biome check .claude/settings.local.json` が対象外として処理される
- [x] `biome check src/` で既存ソースの lint/format が引き続き動作（82 files checked）
- [x] `pnpm build` が成功
- [x] 全テスト通過（337 tests passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)