### PR TITLE
feat: worktree に node_modules を自動 symlink

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,5 +8,8 @@
       "Bash(pnpm build)",
       "Bash(pnpm exec:*)"
     ]
+  },
+  "worktree": {
+    "symlinkDirectories": ["node_modules"]
   }
 }


### PR DESCRIPTION
Closes #92

## Summary
- `worktree.symlinkDirectories` 設定により、worktree 作成時に main の `node_modules` をシンボリックリンク
- WorktreeCreate フックの代わりにビルトイン設定を採用（1行で完結、メンテナンス不要）

## 実装判断
Issue では `.claude/hooks/setup-worktree.sh` による WorktreeCreate フック実装を想定していましたが、Claude Code の settings schema に `worktree.symlinkDirectories` が存在することが判明。この設定は Issue の受け入れ条件を全て満たすため、よりシンプルな方法を採用しました。

## Test plan
- [ ] `claude --worktree` で作成された worktree に `node_modules` symlink が自動作成される
- [ ] worktree 内で `pnpm test` が成功する（手動 install 不要）
- [ ] worktree 内で `pnpm build` が成功する
- [ ] main の `node_modules` を変更した場合、worktree にも即座に反映される
- [ ] 複数 worktree を同時に作成しても問題なく動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)