### PR TITLE
feat: Epic sub-issue 全完了時に Project Status を自動 Done 化

### DIFF
--- a/.github/workflows/epic-auto-done.yml
+++ b/.github/workflows/epic-auto-done.yml
@@ -30,7 +30,7 @@ jobs:
             query($owner: String!, $repo: String!, $number: Int!) {
               repository(owner: $owner, name: $repo) {
                 issue(number: $number) {
-                  trackedInIssues(first: 10) {
+                  trackedInIssues(first: 25) {
                     nodes {
                       number
                       state
@@ -95,14 +95,15 @@ jobs:
             NODE_COUNT=$(echo "$SUBISSUES" | jq '.data.repository.issue.subIssues.nodes | length')
             CLOSED_COUNT=$(echo "$SUBISSUES" | jq '[.data.repository.issue.subIssues.nodes[] | select(.state == "CLOSED")] | length')
 
-            if [ "$NODE_COUNT" -lt "$TOTAL" ]; then
-              echo "::warning::Epic #${parent_number} has ${TOTAL} sub-issues but only ${NODE_COUNT} were fetched. Result may be incomplete."
-            fi
-
-            echo "Epic #${parent_number}: total=${TOTAL}, closed=${CLOSED_COUNT}"
+            echo "Epic #${parent_number}: total=${TOTAL}, fetched=${NODE_COUNT}, closed=${CLOSED_COUNT}"
 
             if [ "$TOTAL" -eq 0 ]; then
               echo "Epic #${parent_number} has no sub-issues, skipping."
+              continue
+            fi
+
+            if [ "$NODE_COUNT" -lt "$TOTAL" ]; then
+              echo "::warning::Epic #${parent_number} has ${TOTAL} sub-issues but only ${NODE_COUNT} were fetched. Skipping to avoid incomplete judgment."
               continue
             fi
 


### PR DESCRIPTION
## Summary
- Issue クローズ時に親 epic の sub-issue 完了状態を自動判定し、全完了なら Project Status を Done に更新するワークフローを追加
- GraphQL `trackedInIssues` / `subIssues` API を使用して親子関係を解決
- Script Injection 対策として `${{ }}` を全て env 経由に変更、GraphQL エラーハンドリング付き

## Test plan
- [ ] sub-issue を持つ epic を用意し、全 sub-issue をクローズして Status が Done になることを確認
- [ ] 一部 sub-issue が open の状態でクローズしても Status が変わらないことを確認
- [ ] 親 Issue を持たない Issue のクローズ時にスキップされることを確認
- [ ] `PROJECT_TOKEN` シークレットが設定されていることを確認

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)