### PR TITLE
refactor: cleanDescription 関数を削除

### DIFF
--- a/src/utils/merge-vim-commands.ts
+++ b/src/utils/merge-vim-commands.ts
@@ -42,7 +42,7 @@ export function mergeWithNvimMaps(
       const newEntryKey = makeEntryKey(key, expandedModes);
       if (addedNewEntryKeys.has(newEntryKey)) continue;
 
-      const description = cleanDescription(nvMap.description);
+      const description = nvMap.description;
       if (!description) continue; // description なしはスキップ
 
       merged.push({
@@ -97,12 +97,4 @@ function normalizeNvimKey(lhs: string): string {
     /<C-(\w)>/gi,
     (_, ch: string) => `<C-${ch.toLowerCase()}>`,
   );
-}
-
-/**
- * nvim の description をクリーンアップ
- */
-function cleanDescription(desc: string): string {
-  if (!desc) return "";
-  return desc;
 }


### PR DESCRIPTION
## Summary
- `src/utils/merge-vim-commands.ts` の実質 no-op だった `cleanDescription` 関数を削除
- 呼び出し元で `nvMap.description` を直接参照するように変更
- 既存テスト全 17 件 pass 確認済み

Closes #84

## Test plan
- [x] 既存テスト全 pass (`merge-vim-commands.test.ts` 17 tests)
- [x] Biome check pass
- [x] 型チェック pass
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>