### PR TITLE
refactor: AppMode 型エイリアスを抽出

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ import {
 } from "./data/vim-commands";
 import { useKeyboardLayout } from "./hooks/useKeyboardLayout";
 import { useNvimMaps } from "./hooks/useNvimMaps";
-import type { KeybindingConfig, VimMode } from "./types/keybinding";
+import type { AppMode, KeybindingConfig, VimMode } from "./types/keybinding";
 import type { HighlightEntry, VIAKeymapFull, VimCommand } from "./types/vim";
 import { mergeWithNvimMaps } from "./utils/merge-vim-commands";
 import {
@@ -54,9 +54,7 @@ function AppContent() {
   const [viaKeymapFull, setViaKeymapFull] = useState<VIAKeymapFull | null>(
     null,
   );
-  const [mode, setMode] = useState<
-    "visualize" | "practice" | "reference" | "edit"
-  >("visualize");
+  const [mode, setMode] = useState<AppMode>("visualize");
   const [activeVimMode, setActiveVimMode] = useState<VimMode>("n");
   const [highlightKeys, setHighlightKeys] = useState<HighlightEntry[]>([]);
   const [keymapFileName, setKeymapFileName] = useState<string | null>(null);

--- a/src/types/keybinding.test.ts
+++ b/src/types/keybinding.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import type { AppMode } from "./keybinding";
+import { APP_MODES } from "./keybinding";
+
+describe("APP_MODES", () => {
+  test("4つの要素を持つ", () => {
+    expect(APP_MODES).toHaveLength(4);
+  });
+
+  describe("全ての AppMode 値を含む", () => {
+    const cases: AppMode[] = ["visualize", "practice", "reference", "edit"];
+
+    test.each(cases)('"%s" を含む', (mode) => {
+      expect(APP_MODES).toContain(mode);
+    });
+  });
+
+  test("重複がない", () => {
+    const unique = new Set<string>(APP_MODES);
+    expect(unique.size).toBe(APP_MODES.length);
+  });
+});

--- a/src/types/keybinding.ts
+++ b/src/types/keybinding.ts
@@ -15,6 +15,17 @@ export const VIM_MODES = [
   "t",
 ] as const satisfies VimMode[];
 
+/** アプリモード */
+export type AppMode = "visualize" | "practice" | "reference" | "edit";
+
+/** AppMode の全値リスト */
+export const APP_MODES = [
+  "visualize",
+  "practice",
+  "reference",
+  "edit",
+] as const satisfies AppMode[];
+
 /** バインディングの出自 */
 export type KeybindingSource =
   | "default"


### PR DESCRIPTION
Closes #103

## Summary
- `src/types/keybinding.ts` に `AppMode` 型エイリアスと `APP_MODES` 定数配列を追加（`VimMode` / `VIM_MODES` と同パターン）
- `src/App.tsx` の `useState` 型パラメータをインラインユニオンから `AppMode` に置換
- `APP_MODES` のユニットテストを追加（網羅性・重複なし）

## Test plan
- [x] `APP_MODES` ユニットテスト 6件パス
- [x] 既存テスト 358件全パス
- [x] `tsc --noEmit` 型チェック通過
- [x] Biome lint/format チェック通過
- [x] Vite ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)