### PR TITLE
feat: bindings 要素レベルの型検証を追加

### DIFF
--- a/src/utils/storage.test.ts
+++ b/src/utils/storage.test.ts
@@ -386,6 +386,134 @@ describe("isStoredKeybindingConfig", () => {
     expect(isStoredKeybindingConfig(42)).toBe(false);
     expect(isStoredKeybindingConfig(undefined)).toBe(false);
   });
+
+  describe("bindings 要素レベル検証", () => {
+    const validBinding = {
+      lhs: "j",
+      name: "下に移動",
+      description: "カーソルを下に移動",
+      category: "motion",
+      source: "default",
+      noremap: true,
+    };
+
+    const allModesWithBinding = {
+      n: [validBinding],
+      v: [validBinding],
+      x: [validBinding],
+      o: [validBinding],
+      i: [validBinding],
+      s: [validBinding],
+      c: [validBinding],
+      t: [validBinding],
+    };
+
+    it("全モードが空配列の場合 true を返す", () => {
+      expect(isStoredKeybindingConfig(validConfig)).toBe(true);
+    });
+
+    it("正常な Keybinding 要素を含む場合 true を返す", () => {
+      const config = { ...validConfig, bindings: allModesWithBinding };
+      expect(isStoredKeybindingConfig(config)).toBe(true);
+    });
+
+    it("lhs が欠落している要素がある場合 false を返す", () => {
+      const { lhs: _lhs, ...withoutLhs } = validBinding;
+      const config = {
+        ...validConfig,
+        bindings: { ...allModesWithBinding, n: [withoutLhs] },
+      };
+      expect(isStoredKeybindingConfig(config)).toBe(false);
+    });
+
+    it("name が欠落している要素がある場合 false を返す", () => {
+      const { name: _name, ...withoutName } = validBinding;
+      const config = {
+        ...validConfig,
+        bindings: { ...allModesWithBinding, n: [withoutName] },
+      };
+      expect(isStoredKeybindingConfig(config)).toBe(false);
+    });
+
+    it("description が欠落している要素がある場合 false を返す", () => {
+      const { description: _description, ...withoutDescription } = validBinding;
+      const config = {
+        ...validConfig,
+        bindings: { ...allModesWithBinding, n: [withoutDescription] },
+      };
+      expect(isStoredKeybindingConfig(config)).toBe(false);
+    });
+
+    it("source が欠落している要素がある場合 false を返す", () => {
+      const { source: _source, ...withoutSource } = validBinding;
+      const config = {
+        ...validConfig,
+        bindings: { ...allModesWithBinding, n: [withoutSource] },
+      };
+      expect(isStoredKeybindingConfig(config)).toBe(false);
+    });
+
+    it("noremap が欠落している要素がある場合 false を返す", () => {
+      const { noremap: _noremap, ...withoutNoremap } = validBinding;
+      const config = {
+        ...validConfig,
+        bindings: { ...allModesWithBinding, n: [withoutNoremap] },
+      };
+      expect(isStoredKeybindingConfig(config)).toBe(false);
+    });
+
+    it("category が欠落している要素がある場合 false を返す", () => {
+      const { category: _category, ...withoutCategory } = validBinding;
+      const config = {
+        ...validConfig,
+        bindings: { ...allModesWithBinding, n: [withoutCategory] },
+      };
+      expect(isStoredKeybindingConfig(config)).toBe(false);
+    });
+
+    it("noremap が boolean でなく string の場合 false を返す", () => {
+      const withStringNoremap = { ...validBinding, noremap: "true" };
+      const config = {
+        ...validConfig,
+        bindings: { ...allModesWithBinding, n: [withStringNoremap] },
+      };
+      expect(isStoredKeybindingConfig(config)).toBe(false);
+    });
+
+    it("要素がオブジェクトでなく文字列の場合 false を返す", () => {
+      const config = {
+        ...validConfig,
+        bindings: { ...allModesWithBinding, n: ["j"] },
+      };
+      expect(isStoredKeybindingConfig(config)).toBe(false);
+    });
+
+    it("要素がオブジェクトでなく数値の場合 false を返す", () => {
+      const config = {
+        ...validConfig,
+        bindings: { ...allModesWithBinding, n: [42] },
+      };
+      expect(isStoredKeybindingConfig(config)).toBe(false);
+    });
+
+    it("一部のモードに正常な要素があり、別のモードに不正な要素がある場合 false を返す", () => {
+      const { lhs: _lhs, ...withoutLhs } = validBinding;
+      const config = {
+        ...validConfig,
+        bindings: {
+          n: [validBinding],
+          v: [validBinding],
+          x: [validBinding],
+          o: [validBinding],
+          i: [validBinding],
+          s: [validBinding],
+          c: [validBinding],
+          t: [withoutLhs],
+        },
+      };
+      expect(isStoredKeybindingConfig(config)).toBe(false);
+    });
+  });
 });
 
 describe("保存キー", () => {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -94,11 +94,25 @@ export function clearAllStorage(): void {
   clearKeybindingConfig();
 }
 
-// NOTE: bindings 内の個々の Keybinding オブジェクトは検証しない。
-// スキーマ変更時はここに移行ロジックを追加すること。
+function isValidBindingElement(element: unknown): boolean {
+  if (typeof element !== "object" || element === null) return false;
+  const e = element as Record<string, unknown>;
+  return (
+    typeof e.lhs === "string" &&
+    typeof e.name === "string" &&
+    typeof e.description === "string" &&
+    typeof e.category === "string" &&
+    typeof e.source === "string" &&
+    typeof e.noremap === "boolean"
+  );
+}
+
 function hasValidBindings(bindings: Record<string, unknown>): boolean {
   return VIM_MODES.every(
-    (mode) => mode in bindings && Array.isArray(bindings[mode]),
+    (mode) =>
+      mode in bindings &&
+      Array.isArray(bindings[mode]) &&
+      (bindings[mode] as unknown[]).every(isValidBindingElement),
   );
 }
 


### PR DESCRIPTION
## Summary
- `hasValidBindings` に `isValidBindingElement` による要素レベル検証を追加
- bindings 配列の各要素が Keybinding 型の必須フィールド (lhs, name, description, category, source, noremap) を持つことを検証
- 不正な要素データに対するテストケース 12 件を追加

Closes #97

## Test plan
- [x] 空配列のモードは正常と判定される
- [x] 正常な Keybinding 要素を含む場合 true を返す
- [x] 必須フィールド欠落で false を返す（lhs, name, description, source, noremap, category）
- [x] 型が不正な場合 false を返す（noremap が string）
- [x] 要素がオブジェクトでない場合 false を返す（string, number）
- [x] 一部モードに不正要素がある場合 false を返す
- [x] 既存テスト 44 件が全てパス
- [x] local-ci 全チェック通過（Biome, Test 364/364, Build）

🤖 Generated with [Claude Code](https://claude.com/claude-code)