### PR TITLE
test: ExportPanel のコピー失敗時テストを追加

### DIFF
--- a/src/components/ExportPanel/ExportPanel.test.tsx
+++ b/src/components/ExportPanel/ExportPanel.test.tsx
@@ -225,6 +225,23 @@ describe("ExportPanel", () => {
       ).toBeInTheDocument();
     });
 
+    test("コピー失敗時「失敗」が表示される", async () => {
+      const user = userEvent.setup();
+      const config = buildConfigWithBindings();
+      setupContext(config);
+      vi.stubGlobal("navigator", {
+        clipboard: {
+          writeText: vi.fn().mockRejectedValue(new Error("Clipboard error")),
+        },
+      });
+
+      render(<ExportPanel />);
+
+      await user.click(screen.getByRole("button", { name: "コピー" }));
+
+      expect(screen.getByRole("button", { name: "失敗" })).toBeInTheDocument();
+    });
+
     test("JSON タブに切り替えてコピーすると JSON 出力が渡される", async () => {
       const user = userEvent.setup();
       const config = buildConfigWithBindings();


### PR DESCRIPTION
## Summary
- ExportPanel の `handleCopy` catch ブロック（`copyStatus = "error"` → ラベル「失敗」）のテストカバレッジを追加
- `navigator.clipboard.writeText` が reject した場合にボタンラベルが「失敗」に変わることを検証

Closes #94

## Test plan
- [x] 新規テスト「コピー失敗時「失敗」が表示される」が GREEN
- [x] 既存テスト 16 件全て PASS
- [x] Biome check PASS
- [x] Build PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)