### PR TITLE
feat: ExportPanel のタブに ARIA ロールを追加

### DIFF
--- a/src/components/ExportPanel/ExportPanel.test.tsx
+++ b/src/components/ExportPanel/ExportPanel.test.tsx
@@ -87,7 +87,7 @@ describe("ExportPanel", () => {
 
       render(<ExportPanel />);
 
-      const luaTab = screen.getByRole("button", { name: "Lua" });
+      const luaTab = screen.getByRole("tab", { name: "Lua" });
       expect(luaTab).toBeInTheDocument();
     });
 
@@ -118,7 +118,7 @@ describe("ExportPanel", () => {
 
       render(<ExportPanel />);
 
-      await user.click(screen.getByRole("button", { name: "JSON" }));
+      await user.click(screen.getByRole("tab", { name: "JSON" }));
 
       expect(screen.getByText('{"json": "output"}')).toBeInTheDocument();
     });
@@ -130,7 +130,7 @@ describe("ExportPanel", () => {
 
       render(<ExportPanel />);
 
-      await user.click(screen.getByRole("button", { name: "JSON" }));
+      await user.click(screen.getByRole("tab", { name: "JSON" }));
 
       expect(mockedKeybindingToJSON).toHaveBeenCalledWith(config);
     });
@@ -142,8 +142,8 @@ describe("ExportPanel", () => {
 
       render(<ExportPanel />);
 
-      await user.click(screen.getByRole("button", { name: "JSON" }));
-      await user.click(screen.getByRole("button", { name: "Lua" }));
+      await user.click(screen.getByRole("tab", { name: "JSON" }));
+      await user.click(screen.getByRole("tab", { name: "Lua" }));
 
       expect(screen.getByText("-- lua output")).toBeInTheDocument();
     });
@@ -234,7 +234,7 @@ describe("ExportPanel", () => {
 
       render(<ExportPanel />);
 
-      await user.click(screen.getByRole("button", { name: "JSON" }));
+      await user.click(screen.getByRole("tab", { name: "JSON" }));
       await user.click(screen.getByRole("button", { name: "コピー" }));
 
       expect(writeText).toHaveBeenCalledWith('{"json": "output"}');
@@ -286,11 +286,109 @@ describe("ExportPanel", () => {
 
       render(<ExportPanel />);
 
-      await user.click(screen.getByRole("button", { name: "JSON" }));
+      await user.click(screen.getByRole("tab", { name: "JSON" }));
       await user.click(screen.getByRole("button", { name: "ダウンロード" }));
 
       expect(capturedAnchor).toBeDefined();
       expect(capturedAnchor?.download).toBe("keyviz-config.json");
+    });
+  });
+
+  describe("ARIA ロール", () => {
+    test("タブコンテナに role='tablist' が付与されている", () => {
+      const config = buildConfigWithBindings();
+      setupContext(config);
+
+      render(<ExportPanel />);
+
+      expect(screen.getByRole("tablist")).toBeInTheDocument();
+    });
+
+    test("各タブに role='tab' が付与されている", () => {
+      const config = buildConfigWithBindings();
+      setupContext(config);
+
+      render(<ExportPanel />);
+
+      const tabs = screen.getAllByRole("tab");
+      expect(tabs).toHaveLength(2);
+    });
+
+    test("デフォルト表示で Lua タブの aria-selected が true、JSON タブが false", () => {
+      const config = buildConfigWithBindings();
+      setupContext(config);
+
+      render(<ExportPanel />);
+
+      expect(screen.getByRole("tab", { name: "Lua" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      expect(screen.getByRole("tab", { name: "JSON" })).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+    });
+
+    test("タブパネルに role='tabpanel' が付与されている", () => {
+      const config = buildConfigWithBindings();
+      setupContext(config);
+
+      render(<ExportPanel />);
+
+      expect(screen.getByRole("tabpanel")).toBeInTheDocument();
+    });
+
+    test("各タブの aria-controls がタブパネルの id と一致する", () => {
+      const config = buildConfigWithBindings();
+      setupContext(config);
+
+      render(<ExportPanel />);
+
+      const tabpanel = screen.getByRole("tabpanel");
+      expect(tabpanel).toHaveAttribute("id", "tabpanel-export");
+
+      const luaTab = screen.getByRole("tab", { name: "Lua" });
+      expect(luaTab).toHaveAttribute("aria-controls", "tabpanel-export");
+
+      const jsonTab = screen.getByRole("tab", { name: "JSON" });
+      expect(jsonTab).toHaveAttribute("aria-controls", "tabpanel-export");
+    });
+
+    test("デフォルト表示でタブパネルの aria-labelledby が Lua タブの id と一致する", () => {
+      const config = buildConfigWithBindings();
+      setupContext(config);
+
+      render(<ExportPanel />);
+
+      const tabpanel = screen.getByRole("tabpanel");
+      expect(tabpanel).toHaveAttribute("aria-labelledby", "tab-lua");
+
+      const luaTab = screen.getByRole("tab", { name: "Lua" });
+      expect(luaTab).toHaveAttribute("id", "tab-lua");
+    });
+
+    test("JSON タブに切り替えると aria-selected と aria-labelledby が更新される", async () => {
+      const user = userEvent.setup();
+      const config = buildConfigWithBindings();
+      setupContext(config);
+
+      render(<ExportPanel />);
+
+      await user.click(screen.getByRole("tab", { name: "JSON" }));
+
+      expect(screen.getByRole("tab", { name: "JSON" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      expect(screen.getByRole("tab", { name: "Lua" })).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+      expect(screen.getByRole("tabpanel")).toHaveAttribute(
+        "aria-labelledby",
+        "tab-json",
+      );
     });
   });
 });

--- a/src/components/ExportPanel/ExportPanel.tsx
+++ b/src/components/ExportPanel/ExportPanel.tsx
@@ -100,11 +100,15 @@ export function ExportPanel() {
   return (
     <div className={styles.container}>
       <div className={styles.toolbar}>
-        <div className={styles.tabs}>
+        <div className={styles.tabs} role="tablist">
           {(["lua", "json"] as ExportFormat[]).map((fmt) => (
             <button
               key={fmt}
               type="button"
+              role="tab"
+              id={`tab-${fmt}`}
+              aria-controls="tabpanel-export"
+              aria-selected={activeFormat === fmt}
               className={`${styles.tab} ${activeFormat === fmt ? styles.tabActive : ""}`}
               onClick={() => handleTabChange(fmt)}
             >
@@ -132,13 +136,19 @@ export function ExportPanel() {
         </div>
       </div>
 
-      {hasBindings ? (
-        <pre className={styles.preview}>{content}</pre>
-      ) : (
-        <p className={styles.empty}>
-          キーバインドが設定されていません。レイアウトとキーマップを読み込んでください。
-        </p>
-      )}
+      <div
+        role="tabpanel"
+        id="tabpanel-export"
+        aria-labelledby={`tab-${activeFormat}`}
+      >
+        {hasBindings ? (
+          <pre className={styles.preview}>{content}</pre>
+        ) : (
+          <p className={styles.empty}>
+            キーバインドが設定されていません。レイアウトとキーマップを読み込んでください。
+          </p>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- ExportPanel のタブ UI に WAI-ARIA タブパターンを実装
- `role="tablist"` / `role="tab"` / `role="tabpanel"` と `aria-selected`, `aria-controls`, `aria-labelledby` による関連付けを追加
- 既存テストを ARIA ロール対応に更新し、ARIA 属性検証テスト 7 件を追加（計 22 テスト）

Closes #96

## Test plan
- [x] 全 377 テスト通過（うち ExportPanel 22 テスト）
- [x] Biome check PASS
- [x] TypeScript 型チェック PASS
- [x] プロダクションビルド PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)