### PR TITLE
feat: プリセット選択 UI を LayoutLoader に追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ const CORNE_V4_MATRIX_COLS = 7;
 const KEYMAP_LOADED_LABEL = "keymap loaded";
 
 function AppContent() {
-  const { config } = useKeybindingContext();
+  const { config, dispatch } = useKeybindingContext();
 
   // Context の customKeymap を優先し、未設定の場合はデフォルトにフォールバック
   const customKeymap = useMemo(
@@ -132,6 +132,13 @@ function AppContent() {
     [matrixCols],
   );
 
+  const handleSelectPreset = useCallback(
+    (keymap: Record<string, string>) => {
+      dispatch({ type: "IMPORT_LAYOUT", customKeymap: keymap });
+    },
+    [dispatch],
+  );
+
   const handleClearStorage = useCallback(() => {
     clearAllStorage();
     // デフォルト状態に戻す
@@ -221,8 +228,10 @@ function AppContent() {
         <LayoutLoader
           layoutName={layout.name}
           keymapFileName={keymapFileName}
+          customKeymap={customKeymap}
           onLoadLayout={handleLoadLayout}
           onLoadKeymap={handleLoadKeymap}
+          onSelectPreset={handleSelectPreset}
           onClearStorage={handleClearStorage}
           error={error}
         />

--- a/src/components/LayoutLoader/LayoutLoader.module.css
+++ b/src/components/LayoutLoader/LayoutLoader.module.css
@@ -65,3 +65,32 @@
   border-color: #f38ba8;
   color: #f38ba8;
 }
+
+.keymapGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-width: 250px;
+}
+
+.presetSelect {
+  background: #1e1e2e;
+  border: 2px solid #45475a;
+  border-radius: 8px;
+  padding: 8px 12px;
+  color: #cdd6f4;
+  font-size: 13px;
+  cursor: pointer;
+  transition:
+    border-color 0.2s,
+    color 0.2s;
+  appearance: none;
+  width: 100%;
+}
+
+.presetSelect:hover,
+.presetSelect:focus {
+  border-color: #89b4fa;
+  outline: none;
+}

--- a/src/components/LayoutLoader/LayoutLoader.test.tsx
+++ b/src/components/LayoutLoader/LayoutLoader.test.tsx
@@ -1,13 +1,16 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, test, vi } from "vitest";
+import { defaultCustomKeymap } from "../../data/keymap";
 import { LayoutLoader } from "./LayoutLoader";
 
 const defaultProps = {
   layoutName: "ANSI 60%",
   keymapFileName: null,
+  customKeymap: defaultCustomKeymap,
   onLoadLayout: vi.fn(),
   onLoadKeymap: vi.fn(),
+  onSelectPreset: vi.fn(),
   onClearStorage: vi.fn(),
   error: null,
 };
@@ -48,9 +51,7 @@ describe("LayoutLoader", () => {
 
     expect(screen.getByText("my-keymap.json")).toBeInTheDocument();
     expect(
-      screen.queryByText(
-        "VIA エクスポートした keymap JSON をドロップ or クリック",
-      ),
+      screen.queryByText("または VIA JSON をドロップ or クリック"),
     ).not.toBeInTheDocument();
   });
 
@@ -80,5 +81,80 @@ describe("LayoutLoader", () => {
     );
 
     expect(onClearStorage).toHaveBeenCalledOnce();
+  });
+
+  test("プリセット選択ドロップダウンが表示される", () => {
+    render(<LayoutLoader {...defaultProps} />);
+
+    const select = screen.getByRole("combobox");
+    expect(select).toBeInTheDocument();
+    expect(screen.getByText("QWERTY")).toBeInTheDocument();
+    expect(screen.getByText("Colemak DH")).toBeInTheDocument();
+    expect(screen.getByText("Dvorak")).toBeInTheDocument();
+  });
+
+  test("customKeymap がプリセットに一致する場合、そのプリセットが選択状態になる", () => {
+    const qwertyKeymap = Object.fromEntries(
+      [
+        "q",
+        "w",
+        "e",
+        "r",
+        "t",
+        "y",
+        "u",
+        "i",
+        "o",
+        "p",
+        "a",
+        "s",
+        "d",
+        "f",
+        "g",
+        "h",
+        "j",
+        "k",
+        "l",
+        ";",
+        "z",
+        "x",
+        "c",
+        "v",
+        "b",
+        "n",
+        "m",
+        ",",
+        ".",
+        "/",
+      ].map((k) => [k, k]),
+    );
+    render(<LayoutLoader {...defaultProps} customKeymap={qwertyKeymap} />);
+
+    const select = screen.getByRole("combobox") as HTMLSelectElement;
+    expect(select.value).toBe("qwerty");
+  });
+
+  test("customKeymap がプリセットに一致しない場合、「カスタム」選択肢が表示される", () => {
+    const customKeymap = { a: "z", z: "a" };
+    render(<LayoutLoader {...defaultProps} customKeymap={customKeymap} />);
+
+    expect(screen.getByText("カスタム")).toBeInTheDocument();
+  });
+
+  test("プリセットを選択すると onSelectPreset が対応する keymap で呼ばれる", async () => {
+    const onSelectPreset = vi.fn();
+    const user = userEvent.setup();
+    render(<LayoutLoader {...defaultProps} onSelectPreset={onSelectPreset} />);
+
+    await user.selectOptions(screen.getByRole("combobox"), "qwerty");
+
+    expect(onSelectPreset).toHaveBeenCalledOnce();
+    // QWERTY キーマップは各キーが自身にマップされている
+    const calledWith = onSelectPreset.mock.calls[0][0] as Record<
+      string,
+      string
+    >;
+    expect(calledWith.q).toBe("q");
+    expect(calledWith.a).toBe("a");
   });
 });

--- a/src/components/LayoutLoader/LayoutLoader.tsx
+++ b/src/components/LayoutLoader/LayoutLoader.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useRef } from "react";
+import { getPresets } from "../../data/keybinding-presets";
+import type { KeybindingPreset } from "../../types/keybinding";
 import styles from "./LayoutLoader.module.css";
+
+/** カスタム選択肢の value 定数 */
+const CUSTOM_PRESET_VALUE = "__custom__";
+
+const PRESETS = getPresets();
 
 interface FileDropZoneProps {
   label: string;
@@ -81,11 +88,32 @@ function FileDropZone({
   );
 }
 
+/** 2 つのキーマップが等しいか比較する */
+function isKeymapEqual(
+  a: Record<string, string>,
+  b: Record<string, string>,
+): boolean {
+  const keysA = Object.keys(a);
+  return (
+    keysA.length === Object.keys(b).length && keysA.every((k) => a[k] === b[k])
+  );
+}
+
+/** 現在のキーマップに一致するプリセットを返す（なければ null） */
+function findMatchingPreset(
+  keymap: Record<string, string>,
+  presets: KeybindingPreset[],
+): KeybindingPreset | null {
+  return presets.find((p) => isKeymapEqual(keymap, p.keymap)) ?? null;
+}
+
 interface LayoutLoaderProps {
   layoutName: string;
   keymapFileName: string | null;
+  customKeymap: Record<string, string>;
   onLoadLayout: (json: string) => void;
   onLoadKeymap: (json: string) => void;
+  onSelectPreset: (keymap: Record<string, string>) => void;
   onClearStorage: () => void;
   error: string | null;
 }
@@ -93,11 +121,28 @@ interface LayoutLoaderProps {
 export function LayoutLoader({
   layoutName,
   keymapFileName,
+  customKeymap,
   onLoadLayout,
   onLoadKeymap,
+  onSelectPreset,
   onClearStorage,
   error,
 }: LayoutLoaderProps) {
+  const matchingPreset = findMatchingPreset(customKeymap, PRESETS);
+  const selectedValue = matchingPreset
+    ? matchingPreset.id
+    : CUSTOM_PRESET_VALUE;
+
+  const handlePresetChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const preset = PRESETS.find((p) => p.id === e.target.value);
+      if (preset) {
+        onSelectPreset(preset.keymap);
+      }
+    },
+    [onSelectPreset],
+  );
+
   return (
     <div className={styles.container}>
       <FileDropZone
@@ -106,12 +151,31 @@ export function LayoutLoader({
         fileName={layoutName !== "ANSI 60%" ? layoutName : null}
         onLoad={onLoadLayout}
       />
-      <FileDropZone
-        label="2. キーマップ"
-        description="VIA エクスポートした keymap JSON をドロップ or クリック"
-        fileName={keymapFileName}
-        onLoad={onLoadKeymap}
-      />
+      {/* select + dropzone を束ねるため、ラベルは group 直下に配置 */}
+      <div className={styles.keymapGroup}>
+        <span className={styles.label}>2. キーマップ</span>
+        <select
+          className={styles.presetSelect}
+          value={selectedValue}
+          onChange={handlePresetChange}
+        >
+          {PRESETS.map((preset) => (
+            <option key={preset.id} value={preset.id}>
+              {preset.name}
+            </option>
+          ))}
+          {/* プリセットに一致しない場合のみ表示 */}
+          {!matchingPreset && (
+            <option value={CUSTOM_PRESET_VALUE}>カスタム</option>
+          )}
+        </select>
+        <FileDropZone
+          label=""
+          description="または VIA JSON をドロップ or クリック"
+          fileName={keymapFileName}
+          onLoad={onLoadKeymap}
+        />
+      </div>
       {error && <span className={styles.error}>{error}</span>}
       <button
         type="button"


### PR DESCRIPTION
## Summary
- LayoutLoader にプリセット選択ドロップダウンを追加し、QWERTY / Colemak DH / Dvorak / Colemak から配列を選択可能に
- 選択したプリセットは `IMPORT_LAYOUT` dispatch 経由で localStorage に自動永続化
- VIA JSON アップロードとの共存を維持（プリセット未一致時は「カスタム」表示）

## Test plan
- [x] プリセット選択ドロップダウンが表示される
- [x] プリセットを選択するとキーボード表示が切り替わる
- [x] 選択したプリセットがページリロード後も維持される
- [x] VIA JSON アップロードとプリセット選択が共存する
- [x] 型チェック・ビルドが通る
- [x] 全テスト通過 (374/374)

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)