### PR TITLE
feat: matchesVimMode でモード階層を考慮した UI フィルタリングを実装

### DIFF
--- a/src/components/CommandReference/CommandReference.test.tsx
+++ b/src/components/CommandReference/CommandReference.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import type { MergedVimCommand } from "../../types/vim";
+import { CommandReference } from "./CommandReference";
+
+const defaultProps = {
+  customKeymap: {},
+  onHighlightKeys: vi.fn(),
+};
+
+describe("CommandReference モードフィルタリング", () => {
+  describe("activeVimMode='v' のとき", () => {
+    test("modes:['x'] のコマンドが表示される", () => {
+      const mergedCommands: MergedVimCommand[] = [
+        {
+          key: "test-x",
+          name: "Visual-exclusive command name",
+          description: "Visual-exclusive command desc",
+          category: "misc",
+          source: "hardcoded",
+          modes: ["x"],
+        },
+      ];
+
+      render(
+        <CommandReference
+          {...defaultProps}
+          mergedCommands={mergedCommands}
+          activeVimMode="v"
+        />,
+      );
+
+      expect(
+        screen.getByText("Visual-exclusive command name"),
+      ).toBeInTheDocument();
+    });
+
+    test("modes:['v', 'x', 's'] のコマンドが1回だけ表示される（冗長表示なし）", () => {
+      const mergedCommands: MergedVimCommand[] = [
+        {
+          key: "test-v",
+          name: "Visual+Select command name",
+          description: "Visual+Select command desc",
+          category: "misc",
+          source: "hardcoded",
+          modes: ["v", "x", "s"],
+        },
+      ];
+
+      render(
+        <CommandReference
+          {...defaultProps}
+          mergedCommands={mergedCommands}
+          activeVimMode="v"
+        />,
+      );
+
+      expect(screen.getAllByText("Visual+Select command name")).toHaveLength(1);
+    });
+
+    test("modes:['n'] のコマンドが表示されない", () => {
+      const mergedCommands: MergedVimCommand[] = [
+        {
+          key: "test-n",
+          name: "Normal mode command name",
+          description: "Normal mode command desc",
+          category: "misc",
+          source: "hardcoded",
+          modes: ["n"],
+        },
+      ];
+
+      render(
+        <CommandReference
+          {...defaultProps}
+          mergedCommands={mergedCommands}
+          activeVimMode="v"
+        />,
+      );
+
+      expect(
+        screen.queryByText("Normal mode command name"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("activeVimMode='s' のとき", () => {
+    test("modes:['v'] のコマンドが表示される", () => {
+      const mergedCommands: MergedVimCommand[] = [
+        {
+          key: "test-v-in-s",
+          name: "Visual+Select command in Select mode name",
+          description: "Visual+Select command in Select mode desc",
+          category: "misc",
+          source: "hardcoded",
+          modes: ["v"],
+        },
+      ];
+
+      render(
+        <CommandReference
+          {...defaultProps}
+          mergedCommands={mergedCommands}
+          activeVimMode="s"
+        />,
+      );
+
+      expect(
+        screen.getByText("Visual+Select command in Select mode name"),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/CommandReference/CommandReference.tsx
+++ b/src/components/CommandReference/CommandReference.tsx
@@ -15,6 +15,7 @@ import type {
   VimCommandCategory,
   VimCommandSource,
 } from "../../types/vim";
+import { matchesVimMode } from "../../types/vim";
 import { resolveVimKey } from "../../utils/vim-key-resolver";
 import styles from "./CommandReference.module.css";
 
@@ -154,7 +155,7 @@ export function CommandReference({
     return commands.filter((cmd) => {
       // モードフィルタ: コマンドの modes に activeVimMode が含まれるか
       const modes = cmd.modes ?? ["n"];
-      if (!modes.includes(activeVimMode)) return false;
+      if (!matchesVimMode(modes, activeVimMode)) return false;
       if (!selectedCategories.has(cmd.category)) return false;
       if (
         hasSources &&

--- a/src/types/vim.test.ts
+++ b/src/types/vim.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { NvimMapMode, VimMode } from "./vim";
-import { expandNvimMapMode } from "./vim";
+import { expandNvimMapMode, matchesVimMode } from "./vim";
 
 describe("expandNvimMapMode", () => {
   describe("単一モードの展開", () => {
@@ -49,6 +49,94 @@ describe("expandNvimMapMode", () => {
         const result = expandNvimMapMode(mode);
         expect(Array.isArray(result)).toBe(true);
         expect(result.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});
+
+describe("matchesVimMode", () => {
+  describe('activeMode="v"（Visual+Select）のマッチ', () => {
+    it('modes に "v" を含む場合は true', () => {
+      const result = matchesVimMode(["v"] satisfies VimMode[], "v");
+      expect(result).toBe(true);
+    });
+
+    it('modes に "x"（Visual-exclusive）を含む場合は true', () => {
+      const result = matchesVimMode(["x"] satisfies VimMode[], "v");
+      expect(result).toBe(true);
+    });
+
+    it('modes に "s"（Select）のみの場合は false', () => {
+      const result = matchesVimMode(["s"] satisfies VimMode[], "v");
+      expect(result).toBe(false);
+    });
+
+    it('modes に "n" のみの場合は false', () => {
+      const result = matchesVimMode(["n"] satisfies VimMode[], "v");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('activeMode="n"（Normal）のマッチ', () => {
+    it('modes に "n" を含む場合は true', () => {
+      const result = matchesVimMode(["n"] satisfies VimMode[], "n");
+      expect(result).toBe(true);
+    });
+
+    it('modes に "v" のみの場合は false', () => {
+      const result = matchesVimMode(["v"] satisfies VimMode[], "n");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('activeMode="s"（Select）のマッチ', () => {
+    it('modes に "s" を含む場合は true', () => {
+      const result = matchesVimMode(["s"] satisfies VimMode[], "s");
+      expect(result).toBe(true);
+    });
+
+    it('modes に "v"（Visual+Select を包含）を含む場合は true', () => {
+      const result = matchesVimMode(["v"] satisfies VimMode[], "s");
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('activeMode="x"（Visual-exclusive）のマッチ', () => {
+    it('modes に "x" を含む場合は true', () => {
+      const result = matchesVimMode(["x"] satisfies VimMode[], "x");
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("その他のモードは自分自身のみにマッチ", () => {
+    it('activeMode="o" で modes に "o" を含む場合は true', () => {
+      const result = matchesVimMode(["o"] satisfies VimMode[], "o");
+      expect(result).toBe(true);
+    });
+
+    it('activeMode="i" で modes に "i" を含む場合は true', () => {
+      const result = matchesVimMode(["i"] satisfies VimMode[], "i");
+      expect(result).toBe(true);
+    });
+
+    it('activeMode="c" で modes に "c" を含む場合は true', () => {
+      const result = matchesVimMode(["c"] satisfies VimMode[], "c");
+      expect(result).toBe(true);
+    });
+
+    it('activeMode="t" で modes に "t" を含む場合は true', () => {
+      const result = matchesVimMode(["t"] satisfies VimMode[], "t");
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("空配列のエッジケース", () => {
+    it("modes が空配列の場合はどのモードでも false", () => {
+      const emptyModes: VimMode[] = [];
+      const allModes: VimMode[] = ["n", "v", "x", "o", "i", "s", "c", "t"];
+      for (const activeMode of allModes) {
+        const result = matchesVimMode(emptyModes, activeMode);
+        expect(result).toBe(false);
       }
     });
   });

--- a/src/types/vim.ts
+++ b/src/types/vim.ts
@@ -45,6 +45,34 @@ export interface NvimMapping {
   sourceDetail: string;
 }
 
+/**
+ * UI のモードセレクタで選択された activeMode に対して、
+ * コマンドの modes 配列がマッチするかを判定する。
+ *
+ * モード階層:
+ * - "v"（Visual+Select）を選択 → "v" または "x"（Visual-exclusive）にマッチ
+ * - "s"（Select）を選択 → "s" または "v"（Visual+Select を包含）にマッチ
+ * - その他 → 自分自身のみにマッチ
+ */
+export function matchesVimMode(
+  commandModes: VimMode[],
+  activeMode: VimMode,
+): boolean {
+  if (commandModes.length === 0) return false;
+
+  // activeMode="v" は "v"（Visual+Select）と "x"（Visual-exclusive）を包含
+  if (activeMode === "v") {
+    return commandModes.includes("v") || commandModes.includes("x");
+  }
+
+  // activeMode="s" は "s"（Select）と "v"（Visual+Select を包含）にマッチ
+  if (activeMode === "s") {
+    return commandModes.includes("s") || commandModes.includes("v");
+  }
+
+  return commandModes.includes(activeMode);
+}
+
 export type VimCommandSource = "hardcoded" | NvimMapSource;
 
 export interface MergedVimCommand extends VimCommand {


### PR DESCRIPTION
## Summary

Closes #90

- `matchesVimMode` 関数を `src/types/vim.ts` に追加。Neovim のモード包含関係（v → v/x、s → s/v）を考慮して UI モードフィルタの判定を行う
- `CommandReference` のフィルタリングを `modes.includes(activeVimMode)` から `matchesVimMode(modes, activeVimMode)` に置換
- `matchesVimMode` の unit テスト 14件、`CommandReference` のコンポーネントテスト 4件を追加

## Test plan

- [x] `matchesVimMode` unit テスト: 全モード・空配列のエッジケース (14件)
- [x] `CommandReference` コンポーネントテスト: activeVimMode="v" で x モードコマンド表示、冗長表示なし確認 (4件)
- [x] 既存テスト全パス (388/388)
- [x] local-ci (Biome / Test / Build) 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)