### PR TITLE
feat: localStorage スキーマ移行戦略の実装

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -67,7 +67,8 @@ vi.mock("./hooks/useNvimMaps", () => ({
 }));
 
 // storage をモック化して localStorage アクセスを回避する
-vi.mock("./utils/storage", () => ({
+vi.mock("./utils/storage", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./utils/storage")>()),
   loadKeymap: vi.fn(() => null),
   loadKeybindingConfig: vi.fn(() => null),
   saveKeymap: vi.fn(),
@@ -91,6 +92,7 @@ const mockedUseNvimMaps = vi.mocked(useNvimMaps);
 function buildConfig(customKeymap?: Record<string, string>): KeybindingConfig {
   const now = new Date().toISOString();
   return {
+    version: 1,
     name: "test-config",
     bindings: emptyBindings(),
     customKeymap,

--- a/src/components/BindingEditor/BindingEditor.test.tsx
+++ b/src/components/BindingEditor/BindingEditor.test.tsx
@@ -18,6 +18,7 @@ const makeBinding = (overrides: Partial<Keybinding> = {}): Keybinding => ({
 });
 
 const makeConfig = (bindings: Keybinding[] = []): KeybindingConfig => ({
+  version: 1,
   name: "test",
   bindings: { ...emptyBindings(), n: bindings },
   createdAt: "2024-01-01T00:00:00Z",

--- a/src/components/ExportPanel/ExportPanel.test.tsx
+++ b/src/components/ExportPanel/ExportPanel.test.tsx
@@ -28,6 +28,7 @@ const mockedKeybindingToJSON = vi.mocked(keybindingToJSON);
 function buildConfig(overrides?: Partial<KeybindingConfig>): KeybindingConfig {
   const now = new Date().toISOString();
   return {
+    version: 1,
     name: "test-config",
     bindings: emptyBindings(),
     createdAt: now,

--- a/src/context/KeybindingContext.test.tsx
+++ b/src/context/KeybindingContext.test.tsx
@@ -2,7 +2,8 @@ import { renderHook } from "@testing-library/react";
 import type React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../utils/storage", () => ({
+vi.mock("../utils/storage", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../utils/storage")>()),
   loadKeybindingConfig: vi.fn(),
   saveKeybindingConfig: vi.fn(),
 }));
@@ -14,6 +15,7 @@ import { KeybindingProvider, useKeybindingContext } from "./KeybindingContext";
 const mockLoadKeybindingConfig = vi.mocked(loadKeybindingConfig);
 
 const savedConfig: KeybindingConfig = {
+  version: 1,
   name: "保存済み設定",
   bindings: {
     n: [
@@ -39,6 +41,7 @@ const savedConfig: KeybindingConfig = {
 };
 
 const initialConfig: KeybindingConfig = {
+  version: 1,
   name: "initial prop 設定",
   bindings: {
     n: [

--- a/src/hooks/useKeybindingConfig.test.ts
+++ b/src/hooks/useKeybindingConfig.test.ts
@@ -1,7 +1,8 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../utils/storage", () => ({
+vi.mock("../utils/storage", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../utils/storage")>()),
   saveKeybindingConfig: vi.fn(),
 }));
 

--- a/src/types/keybinding.ts
+++ b/src/types/keybinding.ts
@@ -55,6 +55,8 @@ export interface Keybinding {
 
 /** キーバインド設定全体 */
 export interface KeybindingConfig {
+  /** スキーマバージョン */
+  version: number;
   /** 設定名 */
   name: string;
   /** モードごとのバインディング */

--- a/src/utils/keybinding-defaults.ts
+++ b/src/utils/keybinding-defaults.ts
@@ -6,6 +6,7 @@ import type {
 } from "../types/keybinding";
 import { emptyBindings } from "../types/keybinding";
 import type { VimCommand } from "../types/vim";
+import { CURRENT_KEYBINDING_VERSION } from "./storage";
 
 /**
  * VimCommand → Keybinding 変換
@@ -42,6 +43,7 @@ export function createDefaultConfig(name = "QWERTY Default"): KeybindingConfig {
 
   const now = new Date().toISOString();
   return {
+    version: CURRENT_KEYBINDING_VERSION,
     name,
     bindings,
     createdAt: now,

--- a/src/utils/keybinding-exporters.test.ts
+++ b/src/utils/keybinding-exporters.test.ts
@@ -22,6 +22,7 @@ function makeConfig(
   overrides: Partial<KeybindingConfig> = {},
 ): KeybindingConfig {
   return {
+    version: 1,
     name: "テスト設定",
     bindings: emptyBindings(),
     createdAt: "2024-01-01T00:00:00.000Z",

--- a/src/utils/keybinding-from-layout.ts
+++ b/src/utils/keybinding-from-layout.ts
@@ -3,6 +3,7 @@ import { decomposeVimKey, vimCommands } from "../data/vim-commands";
 import type { Keybinding, KeybindingConfig } from "../types/keybinding";
 import { emptyBindings } from "../types/keybinding";
 import type { VimCommand } from "../types/vim";
+import { CURRENT_KEYBINDING_VERSION } from "./storage";
 
 /**
  * カスタム配列から KeybindingConfig を生成する。
@@ -47,6 +48,7 @@ export function deriveFromLayout(
 
   const now = new Date().toISOString();
   return {
+    version: CURRENT_KEYBINDING_VERSION,
     name,
     bindings,
     customKeymap,

--- a/src/utils/storage.test.ts
+++ b/src/utils/storage.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { KeybindingConfig } from "../types/keybinding";
 import {
+  CURRENT_KEYBINDING_VERSION,
   clearAllStorage,
   clearKeybindingConfig,
   clearKeymap,
@@ -9,6 +10,7 @@ import {
   loadKeybindingConfig,
   loadKeymap,
   loadLayout,
+  migrateKeybindingConfig,
   saveKeybindingConfig,
   saveKeymap,
   saveLayout,
@@ -159,6 +161,7 @@ describe("clearAllStorage", () => {
 
   it("keybinding-config もクリアされる", () => {
     const config: KeybindingConfig = {
+      version: CURRENT_KEYBINDING_VERSION,
       name: "Test Config",
       bindings: { n: [], v: [], x: [], o: [], i: [], s: [], c: [], t: [] },
       createdAt: "2024-01-01T00:00:00.000Z",
@@ -173,6 +176,7 @@ describe("clearAllStorage", () => {
 });
 
 const validConfig: KeybindingConfig = {
+  version: CURRENT_KEYBINDING_VERSION,
   name: "My Config",
   bindings: { n: [], v: [], x: [], o: [], i: [], s: [], c: [], t: [] },
   createdAt: "2024-01-01T00:00:00.000Z",
@@ -558,5 +562,212 @@ describe("保存キー", () => {
     expect(storedRaw).not.toBeNull();
     const stored = JSON.parse(storedRaw as string);
     expect(stored).toEqual({ json, matrixCols, name });
+  });
+});
+
+describe("マイグレーション: v0 → v1", () => {
+  const v0Config = {
+    name: "v0 Config",
+    bindings: { n: [], v: [], x: [], o: [], i: [], s: [], c: [], t: [] },
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-02T00:00:00.000Z",
+  };
+
+  it("v0 データ（version フィールドなし）が version: 1 に変換される", () => {
+    const result = migrateKeybindingConfig(v0Config);
+
+    expect(result).not.toBeNull();
+    expect(result!.version).toBe(1);
+  });
+
+  it("v0 データの name フィールドが保持される", () => {
+    const result = migrateKeybindingConfig(v0Config);
+
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe("v0 Config");
+  });
+
+  it("v0 データの bindings フィールドが保持される", () => {
+    const result = migrateKeybindingConfig(v0Config);
+
+    expect(result).not.toBeNull();
+    expect(result!.bindings).toEqual(v0Config.bindings);
+  });
+
+  it("v0 データの createdAt フィールドが保持される", () => {
+    const result = migrateKeybindingConfig(v0Config);
+
+    expect(result).not.toBeNull();
+    expect(result!.createdAt).toBe("2024-01-01T00:00:00.000Z");
+  });
+
+  it("v0 データの updatedAt フィールドが保持される", () => {
+    const result = migrateKeybindingConfig(v0Config);
+
+    expect(result).not.toBeNull();
+    expect(result!.updatedAt).toBe("2024-01-02T00:00:00.000Z");
+  });
+
+  it("v0 データの customKeymap フィールドが保持される", () => {
+    const v0WithKeymap = { ...v0Config, customKeymap: { a: "a", s: "r" } };
+
+    const result = migrateKeybindingConfig(v0WithKeymap);
+
+    expect(result).not.toBeNull();
+    expect(result!.customKeymap).toEqual({ a: "a", s: "r" });
+  });
+
+  it("customKeymap がない v0 データも正しく変換される", () => {
+    const result = migrateKeybindingConfig(v0Config);
+
+    expect(result).not.toBeNull();
+    expect(result!.customKeymap).toBeUndefined();
+    expect(result!.version).toBe(1);
+  });
+
+  it("既に version: 1 のデータはそのまま返される", () => {
+    const v1Config = { ...v0Config, version: 1 };
+
+    const result = migrateKeybindingConfig(v1Config);
+
+    expect(result).not.toBeNull();
+    expect(result!.version).toBe(1);
+    expect(result!.name).toBe("v0 Config");
+  });
+});
+
+describe("loadKeybindingConfig のバージョンマイグレーション", () => {
+  const v0ConfigRaw = {
+    name: "Migrated Config",
+    bindings: { n: [], v: [], x: [], o: [], i: [], s: [], c: [], t: [] },
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-02T00:00:00.000Z",
+  };
+
+  it("v0 データを localStorage から読み込むと version: 1 のデータが返る", () => {
+    localStorageMock.setItem(
+      "keyviz:keybinding-config",
+      JSON.stringify(v0ConfigRaw),
+    );
+
+    const result = loadKeybindingConfig();
+
+    expect(result).not.toBeNull();
+    expect(result?.version).toBe(1);
+  });
+
+  it("v0 データを読み込んだ後 name や bindings が保持される", () => {
+    localStorageMock.setItem(
+      "keyviz:keybinding-config",
+      JSON.stringify(v0ConfigRaw),
+    );
+
+    const result = loadKeybindingConfig();
+
+    expect(result?.name).toBe("Migrated Config");
+    expect(result?.bindings).toEqual(v0ConfigRaw.bindings);
+  });
+
+  it("マイグレーション後のデータが localStorage に再保存される（永続化）", () => {
+    localStorageMock.setItem(
+      "keyviz:keybinding-config",
+      JSON.stringify(v0ConfigRaw),
+    );
+
+    loadKeybindingConfig();
+
+    const storedRaw = localStorageMock.getItem("keyviz:keybinding-config");
+    expect(storedRaw).not.toBeNull();
+    const stored = JSON.parse(storedRaw as string);
+    expect(stored.version).toBe(1);
+  });
+
+  it("マイグレーション不可能な壊れたデータの場合は null を返す", () => {
+    localStorageMock.setItem("keyviz:keybinding-config", "{ broken json ::::");
+
+    const result = loadKeybindingConfig();
+
+    expect(result).toBeNull();
+  });
+
+  it("マイグレーション後に型ガードに失敗するデータの場合は null を返す", () => {
+    localStorageMock.setItem(
+      "keyviz:keybinding-config",
+      JSON.stringify({ name: "incomplete" }),
+    );
+
+    const result = loadKeybindingConfig();
+
+    expect(result).toBeNull();
+  });
+
+  it("壊れたデータの場合は localStorage がクリアされる", () => {
+    localStorageMock.setItem("keyviz:keybinding-config", "{ broken json ::::");
+
+    loadKeybindingConfig();
+
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith(
+      "keyviz:keybinding-config",
+    );
+  });
+});
+
+describe("isStoredKeybindingConfig の version 検証", () => {
+  it("version: 1 を含む正常なデータは true を返す", () => {
+    expect(isStoredKeybindingConfig(validConfig)).toBe(true);
+  });
+
+  it("version フィールドがない（v0）データは false を返す", () => {
+    const v0Data = {
+      name: "v0 Config",
+      bindings: { n: [], v: [], x: [], o: [], i: [], s: [], c: [], t: [] },
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-02T00:00:00.000Z",
+    };
+
+    expect(isStoredKeybindingConfig(v0Data)).toBe(false);
+  });
+
+  it("version が string の場合は false を返す", () => {
+    const withStringVersion = { ...validConfig, version: "1" };
+
+    expect(isStoredKeybindingConfig(withStringVersion)).toBe(false);
+  });
+
+  it("version が null の場合は false を返す", () => {
+    const withNullVersion = { ...validConfig, version: null };
+
+    expect(isStoredKeybindingConfig(withNullVersion)).toBe(false);
+  });
+
+  it("version が負の数の場合は false を返す", () => {
+    const withNegativeVersion = { ...validConfig, version: -1 };
+
+    expect(isStoredKeybindingConfig(withNegativeVersion)).toBe(false);
+  });
+
+  it("version が 0 の場合は false を返す", () => {
+    const withZeroVersion = { ...validConfig, version: 0 };
+
+    expect(isStoredKeybindingConfig(withZeroVersion)).toBe(false);
+  });
+});
+
+describe("saveKeybindingConfig の version 保持", () => {
+  it("saveKeybindingConfig で保存した config に version: 1 が含まれる", () => {
+    saveKeybindingConfig(validConfig);
+
+    const storedRaw = localStorageMock.getItem("keyviz:keybinding-config");
+    expect(storedRaw).not.toBeNull();
+    const stored = JSON.parse(storedRaw as string);
+    expect(stored.version).toBe(1);
+  });
+
+  it("loadKeybindingConfig で取得した config に version: 1 が含まれる", () => {
+    saveKeybindingConfig(validConfig);
+
+    const result = loadKeybindingConfig();
+
+    expect(result?.version).toBe(1);
   });
 });

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,6 +1,15 @@
 import { type KeybindingConfig, VIM_MODES } from "../types/keybinding";
 
 const STORAGE_PREFIX = "keyviz:";
+
+/** 現在のキーバインド設定スキーマバージョン */
+export const CURRENT_KEYBINDING_VERSION = 1;
+
+/** v0 データ（version フィールドなし）の型 */
+type KeybindingConfigV0 = Omit<KeybindingConfig, "version">;
+
+/** マイグレーション対象データの型（v0 または最新バージョン） */
+type MigrationInput = KeybindingConfigV0 | KeybindingConfig;
 const LAYOUT_KEY = `${STORAGE_PREFIX}layout`;
 const KEYMAP_KEY = `${STORAGE_PREFIX}keymap`;
 const KEYBINDING_CONFIG_KEY = `${STORAGE_PREFIX}keybinding-config`;
@@ -116,6 +125,31 @@ function hasValidBindings(bindings: Record<string, unknown>): boolean {
   );
 }
 
+/**
+ * キーバインド設定を最新バージョンにマイグレーションする。
+ * v0（version フィールドなし）から順次最新バージョンへ変換する。
+ * 未知のバージョンの場合は null を返す。
+ */
+export function migrateKeybindingConfig(
+  data: MigrationInput,
+): KeybindingConfig | null {
+  // version フィールドがない場合は v0 として扱う
+  const version = "version" in data ? data.version : 0;
+
+  if (version === CURRENT_KEYBINDING_VERSION) {
+    // 既に最新バージョン
+    return data as KeybindingConfig;
+  }
+
+  // v0 → v1: version フィールドを追加する
+  if (version === 0) {
+    return { ...data, version: 1 };
+  }
+
+  // 未知のバージョン（将来のバージョンや不正値）
+  return null;
+}
+
 export function isStoredKeybindingConfig(
   value: unknown,
 ): value is KeybindingConfig {
@@ -124,6 +158,10 @@ export function isStoredKeybindingConfig(
   const v = value as Record<string, unknown>;
 
   return (
+    "version" in v &&
+    typeof v.version === "number" &&
+    Number.isInteger(v.version) &&
+    (v.version as number) >= 1 &&
     "name" in v &&
     typeof v.name === "string" &&
     "bindings" in v &&
@@ -146,8 +184,26 @@ export function loadKeybindingConfig(): KeybindingConfig | null {
   if (raw === null) return null;
 
   const parsed = safeJsonParse(raw);
+  if (parsed === null || typeof parsed !== "object") {
+    clearKeybindingConfig();
+    return null;
+  }
+
+  // 既に最新バージョンなら型ガードのみ実行
   if (isStoredKeybindingConfig(parsed)) return parsed;
-  return null;
+
+  // version フィールドがない、または古いバージョンはマイグレーションを試みる
+  const migrated = migrateKeybindingConfig(parsed as MigrationInput);
+
+  if (!isStoredKeybindingConfig(migrated)) {
+    // マイグレーション後も型ガードに失敗した場合はクリア
+    clearKeybindingConfig();
+    return null;
+  }
+
+  // マイグレーション結果を localStorage に再保存して永続化
+  localStorage.setItem(KEYBINDING_CONFIG_KEY, JSON.stringify(migrated));
+  return migrated;
 }
 
 export function clearKeybindingConfig(): void {


### PR DESCRIPTION
## Summary
- `KeybindingConfig` に `version: number` フィールドを追加（初期値 `1`）
- `migrateKeybindingConfig` 関数で v0（version なし）→ v1 のマイグレーションチェーンを実装
- `loadKeybindingConfig` で自動マイグレーション＆永続化、失敗時は localStorage クリア
- `isStoredKeybindingConfig` に version フィールドの型・範囲検証を追加

## Test plan
- [x] v0 → v1 マイグレーション変換テスト（8 ケース）
- [x] loadKeybindingConfig のマイグレーション統合テスト（6 ケース）
- [x] isStoredKeybindingConfig の version 検証テスト（6 ケース）
- [x] saveKeybindingConfig の version 保持テスト（2 ケース）
- [x] 全 392 テストパス
- [x] TypeScript 型チェック通過
- [x] Biome lint/format チェック通過
- [x] プロダクションビルド成功

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)