### PR TITLE
refactor: モードタブボタンを配列 map で宣言的に記述

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -338,6 +338,74 @@ describe("App - nvimMaps の表示", () => {
   });
 });
 
+describe("App - モードタブの宣言的生成", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("APP_MODE_LABELS の全エントリ（可視化・練習・辞書・編集）がボタンとして表示される", () => {
+    const config = buildConfig(undefined);
+
+    renderAppContent(config);
+
+    expect(screen.getByRole("button", { name: "可視化" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "練習" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "辞書" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "編集" })).toBeInTheDocument();
+  });
+
+  test("モードタブがちょうど4つ存在する", () => {
+    const config = buildConfig(undefined);
+
+    renderAppContent(config);
+
+    const modeTabs = screen
+      .getAllByRole("button")
+      .filter((btn) =>
+        ["可視化", "練習", "辞書", "編集"].includes(btn.textContent ?? ""),
+      );
+    expect(modeTabs).toHaveLength(4);
+  });
+
+  test("初期状態は可視化モードであり Keyboard が表示される", () => {
+    const config = buildConfig(undefined);
+
+    renderAppContent(config);
+
+    expect(screen.getByTestId("keyboard")).toBeInTheDocument();
+    expect(screen.queryByTestId("binding-editor")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("practice-mode")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("command-reference")).not.toBeInTheDocument();
+  });
+
+  test("「辞書」モードに切り替えると CommandReference が表示され練習UIは表示されない", async () => {
+    const user = userEvent.setup();
+    const config = buildConfig(undefined);
+
+    renderAppContent(config);
+
+    await user.click(screen.getByRole("button", { name: "辞書" }));
+
+    expect(screen.getByTestId("command-reference")).toBeInTheDocument();
+    expect(screen.queryByTestId("practice-mode")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("binding-editor")).not.toBeInTheDocument();
+  });
+
+  test("「練習」モードから「可視化」モードに戻すと PracticeMode が非表示になる", async () => {
+    const user = userEvent.setup();
+    const config = buildConfig(undefined);
+
+    renderAppContent(config);
+
+    await user.click(screen.getByRole("button", { name: "練習" }));
+    expect(screen.getByTestId("practice-mode")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "可視化" }));
+    expect(screen.queryByTestId("practice-mode")).not.toBeInTheDocument();
+    expect(screen.getByTestId("keyboard")).toBeInTheDocument();
+  });
+});
+
 describe("App - 編集モードの統合", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import {
 import { useKeyboardLayout } from "./hooks/useKeyboardLayout";
 import { useNvimMaps } from "./hooks/useNvimMaps";
 import type { AppMode, KeybindingConfig, VimMode } from "./types/keybinding";
+import { APP_MODE_LABELS, APP_MODES } from "./types/keybinding";
 import type { HighlightEntry, VIAKeymapFull, VimCommand } from "./types/vim";
 import { mergeWithNvimMaps } from "./utils/merge-vim-commands";
 import {
@@ -185,34 +186,16 @@ function AppContent() {
           </div>
           <div className={styles.headerRight}>
             <div className={styles.modeTabs}>
-              <button
-                type="button"
-                className={`${styles.modeTab} ${mode === "visualize" ? styles.modeTabActive : ""}`}
-                onClick={() => setMode("visualize")}
-              >
-                可視化
-              </button>
-              <button
-                type="button"
-                className={`${styles.modeTab} ${mode === "practice" ? styles.modeTabActive : ""}`}
-                onClick={() => setMode("practice")}
-              >
-                練習
-              </button>
-              <button
-                type="button"
-                className={`${styles.modeTab} ${mode === "reference" ? styles.modeTabActive : ""}`}
-                onClick={() => setMode("reference")}
-              >
-                辞書
-              </button>
-              <button
-                type="button"
-                className={`${styles.modeTab} ${mode === "edit" ? styles.modeTabActive : ""}`}
-                onClick={() => setMode("edit")}
-              >
-                編集
-              </button>
+              {APP_MODES.map((m) => (
+                <button
+                  key={m}
+                  type="button"
+                  className={`${styles.modeTab} ${mode === m ? styles.modeTabActive : ""}`}
+                  onClick={() => setMode(m)}
+                >
+                  {APP_MODE_LABELS[m]}
+                </button>
+              ))}
             </div>
             {(mode === "visualize" || mode === "reference") && (
               <ModeSelector

--- a/src/types/keybinding.ts
+++ b/src/types/keybinding.ts
@@ -26,6 +26,14 @@ export const APP_MODES = [
   "edit",
 ] as const satisfies AppMode[];
 
+/** AppMode の表示ラベル */
+export const APP_MODE_LABELS: Record<AppMode, string> = {
+  visualize: "可視化",
+  practice: "練習",
+  reference: "辞書",
+  edit: "編集",
+};
+
 /** バインディングの出自 */
 export type KeybindingSource =
   | "default"


### PR DESCRIPTION
## Summary
- `App.tsx` の4つのモードタブボタン（可視化・練習・辞書・編集）を `APP_MODES.map()` による宣言的な記述に置換
- `APP_MODE_LABELS: Record<AppMode, string>` を `src/types/keybinding.ts` に追加し、モード追加時のラベル定義漏れを型レベルで検出可能に
- モードタブの表示・動作テストを5件追加（計22テスト）

Closes #104

## Test plan
- [x] 全427テストが PASS
- [x] `tsc --noEmit` が PASS
- [x] Biome check が PASS（既存 warning のみ）
- [x] `vite build` が PASS
- [x] 各モードタブのクリックで正しいモードに切り替わることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)