### PR TITLE
refactor: App.module.css の重複 margin-bottom を共通化

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -1,5 +1,9 @@
+:root {
+  --section-gap: 24px;
+}
+
 .header {
-  margin-bottom: 24px;
+  margin-bottom: var(--section-gap);
 }
 
 .headerTop {
@@ -105,7 +109,7 @@
 .keyboardWrapper {
   display: flex;
   justify-content: center;
-  margin-bottom: 24px;
+  margin-bottom: var(--section-gap);
   overflow-x: auto;
   padding: 16px 0;
 }
@@ -118,19 +122,19 @@
 }
 
 .detail {
-  margin-bottom: 24px;
+  margin-bottom: var(--section-gap);
 }
 
 .reference {
-  margin-bottom: 24px;
+  margin-bottom: var(--section-gap);
 }
 
 .editor {
-  margin-bottom: 24px;
+  margin-bottom: var(--section-gap);
 }
 
 .export {
-  margin-bottom: 24px;
+  margin-bottom: var(--section-gap);
 }
 
 .legend {


### PR DESCRIPTION
## Summary
- `margin-bottom: 24px` を持つ 6 クラスを `:root { --section-gap: 24px }` で一元管理し、値のずれリスクを排除

Closes #109

## Test plan
- [x] 既存テスト 422 件全パス
- [x] Biome check PASS
- [x] ビルド成功
- [ ] ブラウザで表示が変更前と同一であることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)