### PR TITLE
feat: ModeSelector に WAI-ARIA tablist/tab 属性を追加

### DIFF
--- a/src/components/BindingEditor/__snapshots__/BindingEditor.test.tsx.snap
+++ b/src/components/BindingEditor/__snapshots__/BindingEditor.test.tsx.snap
@@ -22,9 +22,13 @@ exports[`BindingEditor > スナップショット > バインディングあり�
       </span>
       <div
         class="_tabs_e815f2"
+        role="tablist"
       >
         <button
+          aria-selected="true"
           class="_tab_e815f2 _tabActive_e815f2"
+          id="tab-vim-n"
+          role="tab"
           title="Normal"
           type="button"
         >
@@ -40,7 +44,10 @@ exports[`BindingEditor > スナップショット > バインディングあり�
           </span>
         </button>
         <button
+          aria-selected="false"
           class="_tab_e815f2 "
+          id="tab-vim-v"
+          role="tab"
           title="Visual"
           type="button"
         >
@@ -56,7 +63,10 @@ exports[`BindingEditor > スナップショット > バインディングあり�
           </span>
         </button>
         <button
+          aria-selected="false"
           class="_tab_e815f2 "
+          id="tab-vim-o"
+          role="tab"
           title="Op-pending"
           type="button"
         >
@@ -72,7 +82,10 @@ exports[`BindingEditor > スナップショット > バインディングあり�
           </span>
         </button>
         <button
+          aria-selected="false"
           class="_tab_e815f2 "
+          id="tab-vim-i"
+          role="tab"
           title="Insert"
           type="button"
         >
@@ -88,7 +101,10 @@ exports[`BindingEditor > スナップショット > バインディングあり�
           </span>
         </button>
         <button
+          aria-selected="false"
           class="_tab_e815f2 "
+          id="tab-vim-c"
+          role="tab"
           title="Command-line"
           type="button"
         >
@@ -104,7 +120,10 @@ exports[`BindingEditor > スナップショット > バインディングあり�
           </span>
         </button>
         <button
+          aria-selected="false"
           class="_tab_e815f2 "
+          id="tab-vim-s"
+          role="tab"
           title="Select"
           type="button"
         >
@@ -120,7 +139,10 @@ exports[`BindingEditor > スナップショット > バインディングあり�
           </span>
         </button>
         <button
+          aria-selected="false"
           class="_tab_e815f2 "
+          id="tab-vim-t"
+          role="tab"
           title="Terminal"
           type="button"
         >
@@ -326,9 +348,13 @@ exports[`BindingEditor > スナップショット > バインディングなし�
       </span>
       <div
         class="_tabs_e815f2"
+        role="tablist"
       >
         <button
+          aria-selected="true"
           class="_tab_e815f2 _tabActive_e815f2"
+          id="tab-vim-n"
+          role="tab"
           title="Normal"
           type="button"
         >
@@ -344,7 +370,10 @@ exports[`BindingEditor > スナップショット > バインディングなし�
           </span>
         </button>
         <button
+          aria-selected="false"
           class="_tab_e815f2 "
+          id="tab-vim-v"
+          role="tab"
           title="Visual"
           type="button"
         >
@@ -360,7 +389,10 @@ exports[`BindingEditor > スナップショット > バインディングなし�
           </span>
         </button>
         <button
+          aria-selected="false"
           class="_tab_e815f2 "
+          id="tab-vim-o"
+          role="tab"
           title="Op-pending"
           type="button"
         >
@@ -376,7 +408,10 @@ exports[`BindingEditor > スナップショット > バインディングなし�
           </span>
         </button>
         <button
+          aria-selected="false"
           class="_tab_e815f2 "
+          id="tab-vim-i"
+          role="tab"
           title="Insert"
           type="button"
         >
@@ -392,7 +427,10 @@ exports[`BindingEditor > スナップショット > バインディングなし�
           </span>
         </button>
         <button
+          aria-selected="false"
           class="_tab_e815f2 "
+          id="tab-vim-c"
+          role="tab"
           title="Command-line"
           type="button"
         >
@@ -408,7 +446,10 @@ exports[`BindingEditor > スナップショット > バインディングなし�
           </span>
         </button>
         <button
+          aria-selected="false"
           class="_tab_e815f2 "
+          id="tab-vim-s"
+          role="tab"
           title="Select"
           type="button"
         >
@@ -424,7 +465,10 @@ exports[`BindingEditor > スナップショット > バインディングなし�
           </span>
         </button>
         <button
+          aria-selected="false"
           class="_tab_e815f2 "
+          id="tab-vim-t"
+          role="tab"
           title="Terminal"
           type="button"
         >

--- a/src/components/ModeSelector/ModeSelector.test.tsx
+++ b/src/components/ModeSelector/ModeSelector.test.tsx
@@ -16,7 +16,7 @@ describe("ModeSelector", () => {
     test("全7モード分のボタンがレンダリングされる", () => {
       render(<ModeSelector {...defaultProps} />);
 
-      expect(screen.getAllByRole("button")).toHaveLength(7);
+      expect(screen.getAllByRole("tab")).toHaveLength(7);
     });
 
     test("各ボタンに正しい title 属性（ラベル）がある", () => {
@@ -126,6 +126,70 @@ describe("ModeSelector", () => {
       await user.click(screen.getByTitle("Insert"));
 
       expect(onModeChange).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("アクセシビリティ", () => {
+    test("tabs コンテナに role='tablist' が付与されている", () => {
+      render(<ModeSelector {...defaultProps} />);
+
+      expect(screen.getByRole("tablist")).toBeInTheDocument();
+    });
+
+    test("アクティブモードのタブに aria-selected='true' が付与されている", () => {
+      render(<ModeSelector {...defaultProps} activeMode="n" />);
+
+      expect(screen.getByTitle("Normal")).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+
+    test("非アクティブなタブに aria-selected='false' が付与されている", () => {
+      render(<ModeSelector {...defaultProps} activeMode="n" />);
+
+      expect(screen.getByTitle("Visual")).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+      expect(screen.getByTitle("Op-pending")).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+      expect(screen.getByTitle("Insert")).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+      expect(screen.getByTitle("Command-line")).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+      expect(screen.getByTitle("Select")).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+      expect(screen.getByTitle("Terminal")).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+    });
+
+    test("各タブに id='tab-vim-{mode}' が付与されている", () => {
+      render(<ModeSelector {...defaultProps} />);
+
+      expect(screen.getByTitle("Normal")).toHaveAttribute("id", "tab-vim-n");
+      expect(screen.getByTitle("Visual")).toHaveAttribute("id", "tab-vim-v");
+      expect(screen.getByTitle("Op-pending")).toHaveAttribute(
+        "id",
+        "tab-vim-o",
+      );
+      expect(screen.getByTitle("Insert")).toHaveAttribute("id", "tab-vim-i");
+      expect(screen.getByTitle("Command-line")).toHaveAttribute(
+        "id",
+        "tab-vim-c",
+      );
+      expect(screen.getByTitle("Select")).toHaveAttribute("id", "tab-vim-s");
+      expect(screen.getByTitle("Terminal")).toHaveAttribute("id", "tab-vim-t");
     });
   });
 

--- a/src/components/ModeSelector/ModeSelector.tsx
+++ b/src/components/ModeSelector/ModeSelector.tsx
@@ -20,11 +20,14 @@ export function ModeSelector({ activeMode, onModeChange }: Props) {
   return (
     <div className={styles.container}>
       <span className={styles.label}>Vim mode:</span>
-      <div className={styles.tabs}>
+      <div className={styles.tabs} role="tablist">
         {vimModes.map(({ mode, label, short }) => (
           <button
             type="button"
             key={mode}
+            role="tab"
+            id={`tab-vim-${mode}`}
+            aria-selected={activeMode === mode}
             className={`${styles.tab} ${activeMode === mode ? styles.tabActive : ""}`}
             onClick={() => onModeChange(mode)}
             title={label}

--- a/src/components/ModeSelector/__snapshots__/ModeSelector.test.tsx.snap
+++ b/src/components/ModeSelector/__snapshots__/ModeSelector.test.tsx.snap
@@ -11,9 +11,13 @@ exports[`ModeSelector > スナップショット > activeMode='n' のデフォ�
   </span>
   <div
     class="_tabs_e815f2"
+    role="tablist"
   >
     <button
+      aria-selected="true"
       class="_tab_e815f2 _tabActive_e815f2"
+      id="tab-vim-n"
+      role="tab"
       title="Normal"
       type="button"
     >
@@ -29,7 +33,10 @@ exports[`ModeSelector > スナップショット > activeMode='n' のデフォ�
       </span>
     </button>
     <button
+      aria-selected="false"
       class="_tab_e815f2 "
+      id="tab-vim-v"
+      role="tab"
       title="Visual"
       type="button"
     >
@@ -45,7 +52,10 @@ exports[`ModeSelector > スナップショット > activeMode='n' のデフォ�
       </span>
     </button>
     <button
+      aria-selected="false"
       class="_tab_e815f2 "
+      id="tab-vim-o"
+      role="tab"
       title="Op-pending"
       type="button"
     >
@@ -61,7 +71,10 @@ exports[`ModeSelector > スナップショット > activeMode='n' のデフォ�
       </span>
     </button>
     <button
+      aria-selected="false"
       class="_tab_e815f2 "
+      id="tab-vim-i"
+      role="tab"
       title="Insert"
       type="button"
     >
@@ -77,7 +90,10 @@ exports[`ModeSelector > スナップショット > activeMode='n' のデフォ�
       </span>
     </button>
     <button
+      aria-selected="false"
       class="_tab_e815f2 "
+      id="tab-vim-c"
+      role="tab"
       title="Command-line"
       type="button"
     >
@@ -93,7 +109,10 @@ exports[`ModeSelector > スナップショット > activeMode='n' のデフォ�
       </span>
     </button>
     <button
+      aria-selected="false"
       class="_tab_e815f2 "
+      id="tab-vim-s"
+      role="tab"
       title="Select"
       type="button"
     >
@@ -109,7 +128,10 @@ exports[`ModeSelector > スナップショット > activeMode='n' のデフォ�
       </span>
     </button>
     <button
+      aria-selected="false"
       class="_tab_e815f2 "
+      id="tab-vim-t"
+      role="tab"
       title="Terminal"
       type="button"
     >


### PR DESCRIPTION
## Summary
- ModeSelector のモード切り替えタブに `role="tablist"`, `role="tab"`, `aria-selected`, `id` 属性を追加
- ExportPanel (#134) と同パターンで WAI-ARIA Tabs 仕様に準拠
- スクリーンリーダーがモード切り替え UI の意味を正しく把握できるようになる

Closes #117

## Test plan
- [x] tabs コンテナに `role="tablist"` が付与されている
- [x] 各タブボタンに `role="tab"` と `aria-selected` が付与されている
- [x] `aria-selected` がアクティブなモードに応じて動的に切り替わる
- [x] 全 426 テストがパス
- [x] Biome lint / Build チェック成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)