### PR TITLE
refactor: LayoutLoader の "ANSI 60%" マジック文字列を定数化

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { DEFAULT_LAYOUT_NAME } from "./data/default-layout";
 import { defaultCustomKeymap } from "./data/keymap";
 import type { KeybindingConfig } from "./types/keybinding";
 import { emptyBindings } from "./types/keybinding";
@@ -50,7 +51,7 @@ vi.mock("./components/Keyboard/Keyboard", () => ({
 // useKeyboardLayout をモック化してファイルシステムアクセスを回避する
 vi.mock("./hooks/useKeyboardLayout", () => ({
   useKeyboardLayout: vi.fn(() => ({
-    layout: { name: "ANSI 60%", keys: [] },
+    layout: { name: DEFAULT_LAYOUT_NAME, keys: [] },
     loadFromJSON: vi.fn(),
     error: null,
   })),

--- a/src/components/LayoutLoader/LayoutLoader.test.tsx
+++ b/src/components/LayoutLoader/LayoutLoader.test.tsx
@@ -1,11 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, test, vi } from "vitest";
+import { DEFAULT_LAYOUT_NAME } from "../../data/default-layout";
 import { defaultCustomKeymap } from "../../data/keymap";
 import { LayoutLoader } from "./LayoutLoader";
 
 const defaultProps = {
-  layoutName: "ANSI 60%",
+  layoutName: DEFAULT_LAYOUT_NAME,
   keymapFileName: null,
   customKeymap: defaultCustomKeymap,
   onLoadLayout: vi.fn(),
@@ -27,9 +28,9 @@ describe("LayoutLoader", () => {
   });
 
   test("layoutName が 'ANSI 60%' の場合、レイアウトドロップゾーンにファイル名が表示されない", () => {
-    render(<LayoutLoader {...defaultProps} layoutName="ANSI 60%" />);
+    render(<LayoutLoader {...defaultProps} layoutName={DEFAULT_LAYOUT_NAME} />);
 
-    expect(screen.queryByText("ANSI 60%")).not.toBeInTheDocument();
+    expect(screen.queryByText(DEFAULT_LAYOUT_NAME)).not.toBeInTheDocument();
     expect(
       screen.getByText("VIA 定義 JSON をドロップ or クリック"),
     ).toBeInTheDocument();

--- a/src/components/LayoutLoader/LayoutLoader.tsx
+++ b/src/components/LayoutLoader/LayoutLoader.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useRef } from "react";
+import { DEFAULT_LAYOUT_NAME } from "../../data/default-layout";
 import { getPresets } from "../../data/keybinding-presets";
 import type { KeybindingPreset } from "../../types/keybinding";
 import styles from "./LayoutLoader.module.css";
@@ -148,7 +149,7 @@ export function LayoutLoader({
       <FileDropZone
         label="1. キーボードレイアウト"
         description="VIA 定義 JSON をドロップ or クリック"
-        fileName={layoutName !== "ANSI 60%" ? layoutName : null}
+        fileName={layoutName !== DEFAULT_LAYOUT_NAME ? layoutName : null}
         onLoad={onLoadLayout}
       />
       {/* select + dropzone を束ねるため、ラベルは group 直下に配置 */}

--- a/src/data/default-layout.test.ts
+++ b/src/data/default-layout.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_LAYOUT_NAME } from "./default-layout";
+import defaultLayoutJson from "./default-layout.json";
+
+describe("DEFAULT_LAYOUT_NAME", () => {
+  it('"ANSI 60%" である', () => {
+    expect(DEFAULT_LAYOUT_NAME).toBe("ANSI 60%");
+  });
+
+  it("default-layout.json の name フィールドと一致する", () => {
+    expect(DEFAULT_LAYOUT_NAME).toBe(defaultLayoutJson.name);
+  });
+});

--- a/src/data/default-layout.ts
+++ b/src/data/default-layout.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_LAYOUT_NAME = "ANSI 60%";

--- a/src/hooks/useKeyboardLayout.test.ts
+++ b/src/hooks/useKeyboardLayout.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_LAYOUT_NAME } from "../data/default-layout";
 import { useKeyboardLayout } from "./useKeyboardLayout";
 
 vi.mock("../utils/storage", () => ({
@@ -27,7 +28,7 @@ describe("初期化時の localStorage 復元", () => {
 
     const { result } = renderHook(() => useKeyboardLayout());
 
-    expect(result.current.layout.name).toBe("ANSI 60%");
+    expect(result.current.layout.name).toBe(DEFAULT_LAYOUT_NAME);
   });
 
   it("localStorage に有効なデータがある → 復元されたレイアウトが返される", () => {
@@ -48,7 +49,7 @@ describe("初期化時の localStorage 復元", () => {
 
     const { result } = renderHook(() => useKeyboardLayout());
 
-    expect(result.current.layout.name).toBe("ANSI 60%");
+    expect(result.current.layout.name).toBe(DEFAULT_LAYOUT_NAME);
   });
 });
 


### PR DESCRIPTION
## Summary
- `src/data/default-layout.ts` に `DEFAULT_LAYOUT_NAME` 定数を新規定義
- `LayoutLoader.tsx` の文字列リテラル `"ANSI 60%"` を定数参照に置換
- テストファイル（`LayoutLoader.test.tsx`, `useKeyboardLayout.test.ts`, `App.test.tsx`）も定数参照に更新

Closes #135

## Test plan
- [x] `DEFAULT_LAYOUT_NAME` が `"ANSI 60%"` であることを検証する unit テスト追加
- [x] `DEFAULT_LAYOUT_NAME` が `default-layout.json` の `name` フィールドと一致することを検証
- [x] 既存テスト 424 件が全てパス
- [x] Biome lint / TypeScript 型チェック PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)