### PR TITLE
refactor: handleHover を useCallback でラップ

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -409,6 +409,35 @@ describe("App - 編集モードの統合", () => {
   });
 });
 
+describe("App - handleHover の参照安定性", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // handleHover が useCallback でラップされていれば、
+  // 再レンダー後も Keyboard に渡される onHover は同一参照であること
+  test("可視化モードで再レンダーされても Keyboard に渡される onHover の参照が変わらない", async () => {
+    const user = userEvent.setup();
+    const config = buildConfig(undefined);
+
+    renderAppContent(config);
+
+    // 初回レンダー時の onHover 参照を取得
+    const calls = mockedKeyboard.mock.calls;
+    const firstOnHover = calls[calls.length - 1][0].onHover;
+
+    // Vim モードタブをクリックして AppContent を再レンダーさせる
+    // ModeSelector は可視化モード時に表示され、クリックで setActiveVimMode が呼ばれる
+    await user.click(screen.getByRole("tab", { name: "VVisual" }));
+
+    // 再レンダー後の onHover 参照を取得
+    const callsAfter = mockedKeyboard.mock.calls;
+    const secondOnHover = callsAfter[callsAfter.length - 1][0].onHover;
+
+    expect(secondOnHover).toBe(firstOnHover);
+  });
+});
+
 describe("App - モードタブの動的生成", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,10 +89,13 @@ function AppContent() {
     [nvimMaps],
   );
 
-  const handleHover = (cmd: VimCommand | null, customKey: string | null) => {
-    setHoveredCommand(cmd);
-    setHoveredCustomKey(customKey);
-  };
+  const handleHover = useCallback(
+    (cmd: VimCommand | null, customKey: string | null) => {
+      setHoveredCommand(cmd);
+      setHoveredCustomKey(customKey);
+    },
+    [],
+  );
 
   const handleHighlightKeys = useCallback((keys: HighlightEntry[]) => {
     setHighlightKeys(keys);


### PR DESCRIPTION
## Summary
- `App.tsx` の `handleHover` を `useCallback` でラップして参照安定性を確保
- 他のハンドラ（`handleHighlightKeys`, `handleLoadLayout` 等）との一貫性を統一
- 参照安定性を検証するテストを追加

Closes #128

## Test plan
- [x] `handleHover` が `useCallback` でラップされている
- [x] 依存配列が空 `[]` で適切に設定されている
- [x] 再レンダー後も `onHover` の参照が同一であることをテストで確認
- [x] 既存テスト 465 件すべて PASSED
- [x] Biome lint PASSED
- [x] Build PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)