### PR TITLE
refactor: ExportPanel テストの CSS Modules クラス名依存を解消

### DIFF
--- a/src/components/ExportPanel/ExportPanel.test.tsx
+++ b/src/components/ExportPanel/ExportPanel.test.tsx
@@ -230,7 +230,7 @@ describe("ExportPanel", () => {
       ).toBeInTheDocument();
     });
 
-    test("コピー失敗時「失敗」が表示され、actionButtonError クラスが付与される", async () => {
+    test("コピー失敗時「失敗」が表示され、data-status が error になる", async () => {
       const user = userEvent.setup();
       const config = buildConfigWithBindings();
       setupContext(config);
@@ -246,10 +246,10 @@ describe("ExportPanel", () => {
 
       const button = screen.getByRole("button", { name: "失敗" });
       expect(button).toBeInTheDocument();
-      expect(button.className).toMatch(/actionButtonError/);
+      expect(button).toHaveAttribute("data-status", "error");
     });
 
-    test("コピー成功時、actionButtonError クラスが付与されない", async () => {
+    test("コピー成功時、data-status が copied になる", async () => {
       const user = userEvent.setup();
       const config = buildConfigWithBindings();
       setupContext(config);
@@ -262,7 +262,7 @@ describe("ExportPanel", () => {
       await user.click(screen.getByRole("button", { name: "コピー" }));
 
       const button = screen.getByRole("button", { name: "コピー済み" });
-      expect(button.className).not.toMatch(/actionButtonError/);
+      expect(button).toHaveAttribute("data-status", "copied");
     });
 
     test("JSON タブに切り替えてコピーすると JSON 出力が渡される", async () => {

--- a/src/components/ExportPanel/ExportPanel.tsx
+++ b/src/components/ExportPanel/ExportPanel.tsx
@@ -130,6 +130,7 @@ export function ExportPanel() {
           <button
             type="button"
             className={`${styles.actionButton} ${COPY_STATUS_CLASS[copyStatus]}`}
+            data-status={copyStatus}
             onClick={handleCopy}
             disabled={!content}
           >


### PR DESCRIPTION
## Summary
- コピーボタンに `data-status={copyStatus}` 属性を追加
- テストの `className.toMatch(/actionButtonError/)` を `toHaveAttribute("data-status", ...)` に変更
- CSS Modules の処理方式変更によるテスト破損リスクを解消

Closes #140

## Test plan
- [x] コピーボタンに `data-status` 属性が付与され、copyStatus の値 (idle/copied/error) を反映する
- [x] テストが CSS Modules のクラス名に依存しない
- [x] 既存の視覚的フィードバック（成功/エラーのスタイル）が維持される
- [x] 全テスト通過（464 tests passed）
- [x] Biome check / Build 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>