### PR TITLE
feat: ModeSelector に Visual Block (x) モードタブを追加

### DIFF
--- a/src/components/BindingEditor/__snapshots__/BindingEditor.test.tsx.snap
+++ b/src/components/BindingEditor/__snapshots__/BindingEditor.test.tsx.snap
@@ -65,6 +65,25 @@ exports[`BindingEditor > スナップショット > バインディングあり�
         <button
           aria-selected="false"
           class="_tab_e815f2 "
+          id="tab-vim-x"
+          role="tab"
+          title="Visual Block"
+          type="button"
+        >
+          <span
+            class="_short_e815f2"
+          >
+            X
+          </span>
+          <span
+            class="_full_e815f2"
+          >
+            Visual Block
+          </span>
+        </button>
+        <button
+          aria-selected="false"
+          class="_tab_e815f2 "
           id="tab-vim-o"
           role="tab"
           title="Op-pending"
@@ -386,6 +405,25 @@ exports[`BindingEditor > スナップショット > バインディングなし�
             class="_full_e815f2"
           >
             Visual
+          </span>
+        </button>
+        <button
+          aria-selected="false"
+          class="_tab_e815f2 "
+          id="tab-vim-x"
+          role="tab"
+          title="Visual Block"
+          type="button"
+        >
+          <span
+            class="_short_e815f2"
+          >
+            X
+          </span>
+          <span
+            class="_full_e815f2"
+          >
+            Visual Block
           </span>
         </button>
         <button

--- a/src/components/ModeSelector/ModeSelector.test.tsx
+++ b/src/components/ModeSelector/ModeSelector.test.tsx
@@ -13,10 +13,10 @@ describe("ModeSelector", () => {
     vi.clearAllMocks();
   });
   describe("レンダリング", () => {
-    test("全7モード分のボタンがレンダリングされる", () => {
+    test("全8モード分のボタンがレンダリングされる", () => {
       render(<ModeSelector {...defaultProps} />);
 
-      expect(screen.getAllByRole("tab")).toHaveLength(7);
+      expect(screen.getAllByRole("tab")).toHaveLength(8);
     });
 
     test("各ボタンに正しい title 属性（ラベル）がある", () => {
@@ -24,6 +24,7 @@ describe("ModeSelector", () => {
 
       expect(screen.getByTitle("Normal")).toBeInTheDocument();
       expect(screen.getByTitle("Visual")).toBeInTheDocument();
+      expect(screen.getByTitle("Visual Block")).toBeInTheDocument();
       expect(screen.getByTitle("Op-pending")).toBeInTheDocument();
       expect(screen.getByTitle("Insert")).toBeInTheDocument();
       expect(screen.getByTitle("Command-line")).toBeInTheDocument();
@@ -51,6 +52,14 @@ describe("ModeSelector", () => {
       render(<ModeSelector {...defaultProps} activeMode="s" />);
 
       expect(screen.getByTitle("Select").className).toContain("tabActive");
+    });
+
+    test("activeMode='x' のとき Visual Block ボタンに tabActive クラスが付く", () => {
+      render(<ModeSelector {...defaultProps} activeMode="x" />);
+
+      expect(screen.getByTitle("Visual Block").className).toContain(
+        "tabActive",
+      );
     });
 
     test("activeMode='t' のとき Terminal ボタンに tabActive クラスが付く", () => {
@@ -86,6 +95,16 @@ describe("ModeSelector", () => {
       await user.click(screen.getByTitle("Visual"));
 
       expect(onModeChange).toHaveBeenCalledWith("v");
+    });
+
+    test("Visual Block ボタンクリックで onModeChange が 'x' で呼ばれる", async () => {
+      const onModeChange = vi.fn();
+      const user = userEvent.setup();
+      render(<ModeSelector {...defaultProps} onModeChange={onModeChange} />);
+
+      await user.click(screen.getByTitle("Visual Block"));
+
+      expect(onModeChange).toHaveBeenCalledWith("x");
     });
 
     test("Command-line ボタンクリックで onModeChange が 'c' で呼ばれる", async () => {
@@ -152,6 +171,10 @@ describe("ModeSelector", () => {
         "aria-selected",
         "false",
       );
+      expect(screen.getByTitle("Visual Block")).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
       expect(screen.getByTitle("Op-pending")).toHaveAttribute(
         "aria-selected",
         "false",
@@ -179,6 +202,10 @@ describe("ModeSelector", () => {
 
       expect(screen.getByTitle("Normal")).toHaveAttribute("id", "tab-vim-n");
       expect(screen.getByTitle("Visual")).toHaveAttribute("id", "tab-vim-v");
+      expect(screen.getByTitle("Visual Block")).toHaveAttribute(
+        "id",
+        "tab-vim-x",
+      );
       expect(screen.getByTitle("Op-pending")).toHaveAttribute(
         "id",
         "tab-vim-o",

--- a/src/components/ModeSelector/ModeSelector.tsx
+++ b/src/components/ModeSelector/ModeSelector.tsx
@@ -9,6 +9,7 @@ interface Props {
 const vimModes: { mode: VimMode; label: string; short: string }[] = [
   { mode: "n", label: "Normal", short: "N" },
   { mode: "v", label: "Visual", short: "V" },
+  { mode: "x", label: "Visual Block", short: "X" },
   { mode: "o", label: "Op-pending", short: "O" },
   { mode: "i", label: "Insert", short: "I" },
   { mode: "c", label: "Command-line", short: "C" },

--- a/src/components/ModeSelector/__snapshots__/ModeSelector.test.tsx.snap
+++ b/src/components/ModeSelector/__snapshots__/ModeSelector.test.tsx.snap
@@ -54,6 +54,25 @@ exports[`ModeSelector > スナップショット > activeMode='n' のデフォ�
     <button
       aria-selected="false"
       class="_tab_e815f2 "
+      id="tab-vim-x"
+      role="tab"
+      title="Visual Block"
+      type="button"
+    >
+      <span
+        class="_short_e815f2"
+      >
+        X
+      </span>
+      <span
+        class="_full_e815f2"
+      >
+        Visual Block
+      </span>
+    </button>
+    <button
+      aria-selected="false"
+      class="_tab_e815f2 "
       id="tab-vim-o"
       role="tab"
       title="Op-pending"


### PR DESCRIPTION
## Summary
- ModeSelector の vimModes 配列に `{ mode: "x", label: "Visual Block", short: "X" }` を追加
- VimMode 型（8値）と UI タブ（8エントリ）の整合性を確保
- 既存テスト更新 + 新規テスト2件追加（activeMode="x" の tabActive クラス、クリック時の onModeChange）

Closes #116

## Test plan
- [x] ModeSelector に "Visual Block (X)" タブが表示される
- [x] "x" タブ選択時に `activeMode="x"` が設定される
- [x] 既存のモードタブの動作が変わらない
- [x] 全466テストが通る
- [x] Biome lint PASSED
- [x] Build PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>