### PR TITLE
feat: 型ガードで category/source の値レベル検証を追加

### DIFF
--- a/src/types/keybinding.test.ts
+++ b/src/types/keybinding.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
-import type { AppMode } from "./keybinding";
-import { APP_MODE_LABELS, APP_MODES } from "./keybinding";
+import type { AppMode, KeybindingSource } from "./keybinding";
+import { APP_MODE_LABELS, APP_MODES, KEYBINDING_SOURCES } from "./keybinding";
 
 describe("APP_MODES", () => {
   test("4つの要素を持つ", () => {
@@ -18,6 +18,30 @@ describe("APP_MODES", () => {
   test("重複がない", () => {
     const unique = new Set<string>(APP_MODES);
     expect(unique.size).toBe(APP_MODES.length);
+  });
+});
+
+describe("KEYBINDING_SOURCES", () => {
+  test("4つの要素を持つ", () => {
+    expect(KEYBINDING_SOURCES).toHaveLength(4);
+  });
+
+  describe("全ての KeybindingSource 値を含む", () => {
+    const cases: KeybindingSource[] = [
+      "default",
+      "layout-derived",
+      "nvim-import",
+      "user-edit",
+    ];
+
+    test.each(cases)('"%s" を含む', (source) => {
+      expect(KEYBINDING_SOURCES).toContain(source);
+    });
+  });
+
+  test("重複がない", () => {
+    const unique = new Set<string>(KEYBINDING_SOURCES);
+    expect(unique.size).toBe(KEYBINDING_SOURCES.length);
   });
 });
 

--- a/src/types/keybinding.ts
+++ b/src/types/keybinding.ts
@@ -41,6 +41,14 @@ export type KeybindingSource =
   | "nvim-import"
   | "user-edit";
 
+/** KeybindingSource の全値リスト */
+export const KEYBINDING_SOURCES = [
+  "default",
+  "layout-derived",
+  "nvim-import",
+  "user-edit",
+] as const satisfies KeybindingSource[];
+
 /** 個別のキーバインディング */
 export interface Keybinding {
   /** キーシーケンス ("j", "dd", "<C-f>", "<leader>ff") */

--- a/src/types/vim.test.ts
+++ b/src/types/vim.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from "vitest";
-import type { NvimMapMode, VimMode } from "./vim";
-import { expandNvimMapMode, matchesVimMode } from "./vim";
+import { describe, expect, it, test } from "vitest";
+import type { NvimMapMode, VimCommandCategory, VimMode } from "./vim";
+import {
+  expandNvimMapMode,
+  matchesVimMode,
+  VIM_COMMAND_CATEGORIES,
+} from "./vim";
 
 describe("expandNvimMapMode", () => {
   describe("単一モードの展開", () => {
@@ -139,5 +143,33 @@ describe("matchesVimMode", () => {
         expect(result).toBe(false);
       }
     });
+  });
+});
+
+describe("VIM_COMMAND_CATEGORIES", () => {
+  test("8つの要素を持つ", () => {
+    expect(VIM_COMMAND_CATEGORIES).toHaveLength(8);
+  });
+
+  describe("全ての VimCommandCategory 値を含む", () => {
+    const cases: VimCommandCategory[] = [
+      "motion",
+      "edit",
+      "search",
+      "insert",
+      "visual",
+      "operator",
+      "textobj",
+      "misc",
+    ];
+
+    test.each(cases)('"%s" を含む', (category) => {
+      expect(VIM_COMMAND_CATEGORIES).toContain(category);
+    });
+  });
+
+  test("重複がない", () => {
+    const unique = new Set<string>(VIM_COMMAND_CATEGORIES);
+    expect(unique.size).toBe(VIM_COMMAND_CATEGORIES.length);
   });
 });

--- a/src/types/vim.ts
+++ b/src/types/vim.ts
@@ -12,6 +12,18 @@ export type VimCommandCategory =
   | "textobj"
   | "misc";
 
+/** VimCommandCategory の全値リスト */
+export const VIM_COMMAND_CATEGORIES = [
+  "motion",
+  "edit",
+  "search",
+  "insert",
+  "visual",
+  "operator",
+  "textobj",
+  "misc",
+] as const satisfies VimCommandCategory[];
+
 // ── Neovim map 連携 ──
 
 export type NvimMapMode = "n" | "x" | "o" | "v" | "s" | "!" | "";

--- a/src/utils/storage.test.ts
+++ b/src/utils/storage.test.ts
@@ -500,6 +500,42 @@ describe("isStoredKeybindingConfig", () => {
       expect(isStoredKeybindingConfig(config)).toBe(false);
     });
 
+    it('category が "unknown"（定義外の文字列）の場合 false を返す', () => {
+      const withUnknownCategory = { ...validBinding, category: "unknown" };
+      const config = {
+        ...validConfig,
+        bindings: { ...allModesWithBinding, n: [withUnknownCategory] },
+      };
+      expect(isStoredKeybindingConfig(config)).toBe(false);
+    });
+
+    it('category が ""（空文字列）の場合 false を返す', () => {
+      const withEmptyCategory = { ...validBinding, category: "" };
+      const config = {
+        ...validConfig,
+        bindings: { ...allModesWithBinding, n: [withEmptyCategory] },
+      };
+      expect(isStoredKeybindingConfig(config)).toBe(false);
+    });
+
+    it('source が "unknown"（定義外の文字列）の場合 false を返す', () => {
+      const withUnknownSource = { ...validBinding, source: "unknown" };
+      const config = {
+        ...validConfig,
+        bindings: { ...allModesWithBinding, n: [withUnknownSource] },
+      };
+      expect(isStoredKeybindingConfig(config)).toBe(false);
+    });
+
+    it('source が ""（空文字列）の場合 false を返す', () => {
+      const withEmptySource = { ...validBinding, source: "" };
+      const config = {
+        ...validConfig,
+        bindings: { ...allModesWithBinding, n: [withEmptySource] },
+      };
+      expect(isStoredKeybindingConfig(config)).toBe(false);
+    });
+
     it("一部のモードに正常な要素があり、別のモードに不正な要素がある場合 false を返す", () => {
       const { lhs: _lhs, ...withoutLhs } = validBinding;
       const config = {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,4 +1,10 @@
-import { type KeybindingConfig, VIM_MODES } from "../types/keybinding";
+import {
+  KEYBINDING_SOURCES,
+  type KeybindingConfig,
+  type KeybindingSource,
+  VIM_MODES,
+} from "../types/keybinding";
+import { VIM_COMMAND_CATEGORIES, type VimCommandCategory } from "../types/vim";
 
 const STORAGE_PREFIX = "keyviz:";
 
@@ -110,8 +116,8 @@ function isValidBindingElement(element: unknown): boolean {
     typeof e.lhs === "string" &&
     typeof e.name === "string" &&
     typeof e.description === "string" &&
-    typeof e.category === "string" &&
-    typeof e.source === "string" &&
+    VIM_COMMAND_CATEGORIES.includes(e.category as VimCommandCategory) &&
+    KEYBINDING_SOURCES.includes(e.source as KeybindingSource) &&
     typeof e.noremap === "boolean"
   );
 }


### PR DESCRIPTION
## Summary
- `VIM_COMMAND_CATEGORIES` / `KEYBINDING_SOURCES` 定数配列を追加（`VIM_MODES` / `APP_MODES` パターンに準拠）
- `isValidBindingElement` の `category` / `source` 検証を `typeof === "string"` から `includes` チェックに強化
- 定数配列の網羅性・一意性テスト、不正値拒否テストを追加

Closes #131

## Test plan
- [x] VIM_COMMAND_CATEGORIES が VimCommandCategory の全8値を網羅
- [x] KEYBINDING_SOURCES が KeybindingSource の全4値を網羅
- [x] 定数配列に重複がない
- [x] isValidBindingElement が "unknown" / "" 等の定義外文字列で false を返す
- [x] 全484テスト通過、Biome check / Build 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)