### PR TITLE
fix: worktree で pnpm が sandbox EPERM になる問題を修正

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,5 +11,8 @@
   },
   "worktree": {
     "symlinkDirectories": ["node_modules"]
+  },
+  "sandbox": {
+    "excludedCommands": ["pnpm"]
   }
 }


### PR DESCRIPTION
## Summary
- `.claude/settings.json` に `sandbox.excludedCommands: ["pnpm"]` を追加
- worktree エージェントで `aikido-pnpm.js` が `0.0.0.0` を listen しようとして EPERM になる問題を解消
- `gh` と `git` は sandbox 除外なしで動作するため `pnpm` のみ追加（最小限の変更）

## Test plan
- [x] `pnpm lint` — PASSED
- [x] `pnpm test` — PASSED (535 tests)
- [x] `pnpm build` — PASSED

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)