### PR TITLE
refactor: Catppuccin カラー値を CSS カスタムプロパティに統一

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -16,13 +16,13 @@
 .title {
   font-size: 24px;
   font-weight: 700;
-  color: #cdd6f4;
+  color: var(--ctp-foreground);
   margin-bottom: 4px;
 }
 
 .subtitle {
   font-size: 13px;
-  color: #6c7086;
+  color: var(--ctp-subtext1);
 }
 
 .nvimStatus {
@@ -34,30 +34,30 @@
 }
 
 .nvimLoading {
-  color: #6c7086;
+  color: var(--ctp-subtext1);
 }
 
 .nvimError {
-  color: #f38ba8;
+  color: var(--ctp-red);
 }
 
 .nvimConnected {
-  color: #a6e3a1;
+  color: var(--ctp-green);
 }
 
 .nvimRefresh {
   padding: 1px 6px;
-  border: 1px solid #45475a;
+  border: 1px solid var(--ctp-surface2);
   border-radius: 3px;
   background: transparent;
-  color: #6c7086;
+  color: var(--ctp-subtext1);
   font-size: 10px;
   cursor: pointer;
 }
 
 .nvimRefresh:hover {
-  color: #cdd6f4;
-  border-color: #6c7086;
+  color: var(--ctp-foreground);
+  border-color: var(--ctp-subtext1);
 }
 
 .headerRight {
@@ -70,7 +70,7 @@
 .modeTabs {
   display: flex;
   gap: 4px;
-  background: #181825;
+  background: var(--ctp-mantle);
   border-radius: 6px;
   padding: 3px;
 }
@@ -82,7 +82,7 @@
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
-  color: #6c7086;
+  color: var(--ctp-subtext1);
   background: transparent;
   transition:
     background-color 0.15s,
@@ -90,12 +90,12 @@
 }
 
 .modeTab:hover {
-  color: #a6adc8;
+  color: var(--ctp-text);
 }
 
 .modeTabActive {
-  background: #313244;
-  color: #cdd6f4;
+  background: var(--ctp-surface1);
+  color: var(--ctp-foreground);
 }
 
 .practice {
@@ -118,7 +118,7 @@
   position: sticky;
   top: 0;
   z-index: 10;
-  background: #1e1e2e;
+  background: var(--ctp-base);
 }
 
 .detail {
@@ -149,7 +149,7 @@
   align-items: center;
   gap: 6px;
   font-size: 12px;
-  color: #a6adc8;
+  color: var(--ctp-text);
 }
 
 .legendDot {

--- a/src/__tests__/css-custom-properties.test.ts
+++ b/src/__tests__/css-custom-properties.test.ts
@@ -1,0 +1,148 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(fileURLToPath(import.meta.url), "../../..");
+
+function readCss(relativePath: string): string {
+  return readFileSync(resolve(ROOT, relativePath), "utf-8");
+}
+
+const indexCss = readCss("src/index.css");
+
+function extractRootBlock(css: string): string {
+  const match = css.match(/:root\s*\{([^}]*)\}/);
+  return match ? match[1] : "";
+}
+
+function excludeRootBlock(css: string): string {
+  return css.replace(/:root\s*\{[^}]*\}/g, "");
+}
+
+const CTP_VARIABLES: Array<{ name: string; hex: string }> = [
+  { name: "--ctp-crust", hex: "#11111b" },
+  { name: "--ctp-mantle", hex: "#181825" },
+  { name: "--ctp-base", hex: "#1e1e2e" },
+  { name: "--ctp-surface0", hex: "#24273a" },
+  { name: "--ctp-surface1", hex: "#313244" },
+  { name: "--ctp-surface2", hex: "#45475a" },
+  { name: "--ctp-subtext0", hex: "#7f849c" },
+  { name: "--ctp-subtext1", hex: "#6c7086" },
+  { name: "--ctp-text", hex: "#a6adc8" },
+  { name: "--ctp-foreground", hex: "#cdd6f4" },
+  { name: "--ctp-blue", hex: "#89b4fa" },
+  { name: "--ctp-cyan", hex: "#4fc3f7" },
+  { name: "--ctp-green", hex: "#a6e3a1" },
+  { name: "--ctp-red", hex: "#f38ba8" },
+  { name: "--ctp-peach", hex: "#fab387" },
+  { name: "--ctp-yellow", hex: "#f9e2af" },
+];
+
+const CTP_RGB_PATTERNS: Array<{ name: string; rgbPattern: RegExp }> = [
+  { name: "--ctp-surface2", rgbPattern: /rgba?\(\s*69\s*,\s*71\s*,\s*90/ },
+  { name: "--ctp-blue", rgbPattern: /rgba?\(\s*137\s*,\s*180\s*,\s*250/ },
+  { name: "--ctp-green", rgbPattern: /rgba?\(\s*166\s*,\s*227\s*,\s*161/ },
+  { name: "--ctp-red", rgbPattern: /rgba?\(\s*243\s*,\s*139\s*,\s*168/ },
+  { name: "--ctp-cyan", rgbPattern: /rgba?\(\s*79\s*,\s*195\s*,\s*247/ },
+  { name: "--ctp-crust", rgbPattern: /rgba?\(\s*17\s*,\s*17\s*,\s*27/ },
+  { name: "--ctp-mantle", rgbPattern: /rgba?\(\s*24\s*,\s*24\s*,\s*37/ },
+  { name: "--ctp-base", rgbPattern: /rgba?\(\s*30\s*,\s*30\s*,\s*46/ },
+  { name: "--ctp-surface0", rgbPattern: /rgba?\(\s*36\s*,\s*39\s*,\s*58/ },
+  { name: "--ctp-surface1", rgbPattern: /rgba?\(\s*49\s*,\s*50\s*,\s*68/ },
+  { name: "--ctp-subtext0", rgbPattern: /rgba?\(\s*127\s*,\s*132\s*,\s*156/ },
+  { name: "--ctp-subtext1", rgbPattern: /rgba?\(\s*108\s*,\s*112\s*,\s*134/ },
+  { name: "--ctp-text", rgbPattern: /rgba?\(\s*166\s*,\s*173\s*,\s*200/ },
+  { name: "--ctp-foreground", rgbPattern: /rgba?\(\s*205\s*,\s*214\s*,\s*244/ },
+  { name: "--ctp-peach", rgbPattern: /rgba?\(\s*250\s*,\s*179\s*,\s*135/ },
+  { name: "--ctp-yellow", rgbPattern: /rgba?\(\s*249\s*,\s*226\s*,\s*175/ },
+];
+
+const TARGET_CSS_PATHS = [
+  "src/App.module.css",
+  "src/components/BindingEditor/BindingEditor.module.css",
+  "src/components/CommandDetail/CommandDetail.module.css",
+  "src/components/CommandReference/CommandReference.module.css",
+  "src/components/ExportPanel/ExportPanel.module.css",
+  "src/components/Keyboard/Key.module.css",
+  "src/components/KeyCapture/KeyCapture.module.css",
+  "src/components/LayoutLoader/LayoutLoader.module.css",
+  "src/components/ModeSelector/ModeSelector.module.css",
+  "src/components/PracticeMode/PracticePrompt.module.css",
+];
+
+describe("CSS カスタムプロパティ統合テスト", () => {
+  describe("src/index.css の :root 定義", () => {
+    const rootBlock = extractRootBlock(indexCss);
+
+    it(":root ブロックが存在する", () => {
+      expect(rootBlock).not.toBe("");
+    });
+
+    for (const { name, hex } of CTP_VARIABLES) {
+      it(`${name}: ${hex} が定義されている`, () => {
+        const pattern = new RegExp(
+          `${name.replace(/[-]/g, "\\$&")}\\s*:\\s*${hex.replace(/[#]/g, "\\$&")}`,
+        );
+        expect(
+          pattern.test(rootBlock),
+          `${name} が ${hex} として :root に定義されていない`,
+        ).toBe(true);
+      });
+    }
+  });
+
+  describe("対象 CSS ファイルのハードコード色値排除", () => {
+    for (const filePath of TARGET_CSS_PATHS) {
+      describe(filePath, () => {
+        const cssBody = excludeRootBlock(readCss(filePath));
+
+        it("Catppuccin の hex 色値がハードコードされていない", () => {
+          const found: Array<{ variable: string; hex: string }> = [];
+          for (const { name, hex } of CTP_VARIABLES) {
+            const pattern = new RegExp(hex.replace("#", "#?"), "i");
+            if (pattern.test(cssBody)) {
+              found.push({ variable: name, hex });
+            }
+          }
+          expect(
+            found,
+            `ハードコードされた Catppuccin カラーが残っています: ${JSON.stringify(found)}`,
+          ).toHaveLength(0);
+        });
+
+        it("Catppuccin カラーの rgba() 表現がハードコードされていない", () => {
+          const found: Array<{ variable: string; match: string }> = [];
+          for (const { name, rgbPattern } of CTP_RGB_PATTERNS) {
+            const match = cssBody.match(rgbPattern);
+            if (match) {
+              found.push({ variable: name, match: match[0] });
+            }
+          }
+          expect(
+            found,
+            `ハードコードされた rgba() 形式の Catppuccin カラーが残っています: ${JSON.stringify(found)}`,
+          ).toHaveLength(0);
+        });
+      });
+    }
+  });
+
+  describe("src/index.css の :root 外ブロックのハードコード色値排除", () => {
+    const indexCssBody = excludeRootBlock(indexCss);
+
+    it("Catppuccin の hex 色値が :root 外にハードコードされていない", () => {
+      const found: Array<{ variable: string; hex: string }> = [];
+      for (const { name, hex } of CTP_VARIABLES) {
+        const pattern = new RegExp(hex.replace("#", "#?"), "i");
+        if (pattern.test(indexCssBody)) {
+          found.push({ variable: name, hex });
+        }
+      }
+      expect(
+        found,
+        `index.css の :root 外に Catppuccin カラーが残っています: ${JSON.stringify(found)}`,
+      ).toHaveLength(0);
+    });
+  });
+});

--- a/src/__tests__/node-types.d.ts
+++ b/src/__tests__/node-types.d.ts
@@ -1,0 +1,11 @@
+declare module "node:fs" {
+  export function readFileSync(path: string, encoding: BufferEncoding): string;
+}
+
+declare module "node:path" {
+  export function resolve(...paths: string[]): string;
+}
+
+declare module "node:url" {
+  export function fileURLToPath(url: string | URL): string;
+}

--- a/src/components/BindingEditor/BindingEditor.module.css
+++ b/src/components/BindingEditor/BindingEditor.module.css
@@ -5,9 +5,9 @@
   flex-direction: column;
   gap: 16px;
   padding: 20px;
-  background: #1e1e2e;
+  background: var(--ctp-base);
   border-radius: 12px;
-  border: 1px solid #313244;
+  border: 1px solid var(--ctp-surface1);
 }
 
 .header {
@@ -21,12 +21,12 @@
 .title {
   font-size: 16px;
   font-weight: 600;
-  color: #cdd6f4;
+  color: var(--ctp-foreground);
   margin: 0;
 }
 
 .empty {
-  color: #6c7086;
+  color: var(--ctp-subtext1);
   font-size: 14px;
   text-align: center;
   padding: 32px 0;
@@ -41,12 +41,12 @@
 .headerRow th {
   padding: 8px 12px;
   text-align: left;
-  color: #6c7086;
+  color: var(--ctp-subtext1);
   font-size: 11px;
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  border-bottom: 1px solid #313244;
+  border-bottom: 1px solid var(--ctp-surface1);
 }
 
 .row {
@@ -55,17 +55,17 @@
 }
 
 .row:hover {
-  background: #24273a;
+  background: var(--ctp-surface0);
 }
 
 .rowEditing {
-  background: #181825;
+  background: var(--ctp-mantle);
   cursor: default;
 }
 
 .row td {
   padding: 8px 12px;
-  border-bottom: 1px solid #181825;
+  border-bottom: 1px solid var(--ctp-mantle);
   vertical-align: middle;
 }
 
@@ -97,33 +97,33 @@
 
 .keyBadge {
   display: inline-block;
-  background: #313244;
-  border: 1px solid #45475a;
+  background: var(--ctp-surface1);
+  border: 1px solid var(--ctp-surface2);
   border-radius: 4px;
   padding: 2px 8px;
   font-family: "SF Mono", monospace;
   font-size: 13px;
   font-weight: 600;
-  color: #89b4fa;
+  color: var(--ctp-blue);
   letter-spacing: 0.02em;
 }
 
 .commandName {
   display: block;
-  color: #cdd6f4;
+  color: var(--ctp-foreground);
   font-weight: 500;
 }
 
 .description {
   display: block;
-  color: #6c7086;
+  color: var(--ctp-subtext1);
   font-size: 11px;
   margin-top: 2px;
 }
 
 .badge {
   display: inline-block;
-  background: color-mix(in srgb, var(--badge-color) 15%, #1e1e2e);
+  background: color-mix(in srgb, var(--badge-color) 15%, var(--ctp-base));
   border: 1px solid color-mix(in srgb, var(--badge-color) 50%, transparent);
   color: var(--badge-color);
   border-radius: 4px;
@@ -133,10 +133,10 @@
 }
 
 .actionButton {
-  background: #313244;
-  border: 1px solid #45475a;
+  background: var(--ctp-surface1);
+  border: 1px solid var(--ctp-surface2);
   border-radius: 4px;
-  color: #a6adc8;
+  color: var(--ctp-text);
   font-size: 11px;
   padding: 3px 10px;
   cursor: pointer;
@@ -146,8 +146,8 @@
 }
 
 .actionButton:hover {
-  background: #45475a;
-  color: #cdd6f4;
+  background: var(--ctp-surface2);
+  color: var(--ctp-foreground);
 }
 
 .actionButton + .actionButton {
@@ -155,7 +155,7 @@
 }
 
 .actionButtonRemove:hover {
-  background: color-mix(in srgb, #f38ba8 20%, #313244);
-  border-color: #f38ba8;
-  color: #f38ba8;
+  background: color-mix(in srgb, var(--ctp-red) 20%, var(--ctp-surface1));
+  border-color: var(--ctp-red);
+  color: var(--ctp-red);
 }

--- a/src/components/CommandDetail/CommandDetail.module.css
+++ b/src/components/CommandDetail/CommandDetail.module.css
@@ -1,6 +1,6 @@
 .panel {
-  background: #1e1e2e;
-  border: 1px solid #45475a;
+  background: var(--ctp-base);
+  border: 1px solid var(--ctp-surface2);
   border-radius: 8px;
   padding: 16px 20px;
   min-height: 80px;
@@ -10,7 +10,7 @@
 }
 
 .placeholder {
-  color: #6c7086;
+  color: var(--ctp-subtext1);
   font-size: 14px;
 }
 
@@ -19,7 +19,7 @@
   border-radius: 4px;
   font-size: 11px;
   font-weight: 600;
-  color: #1e1e2e;
+  color: var(--ctp-base);
   white-space: nowrap;
 }
 
@@ -32,25 +32,25 @@
 .commandName {
   font-size: 18px;
   font-weight: 700;
-  color: #cdd6f4;
+  color: var(--ctp-foreground);
 }
 
 .description {
   font-size: 13px;
-  color: #a6adc8;
+  color: var(--ctp-text);
 }
 
 .keys {
   font-size: 12px;
-  color: #6c7086;
+  color: var(--ctp-subtext1);
 }
 
 .keys kbd {
-  background: #313244;
-  border: 1px solid #45475a;
+  background: var(--ctp-surface1);
+  border: 1px solid var(--ctp-surface2);
   border-radius: 3px;
   padding: 1px 6px;
   font-family: "SF Mono", monospace;
   font-size: 12px;
-  color: #cdd6f4;
+  color: var(--ctp-foreground);
 }

--- a/src/components/CommandReference/CommandReference.module.css
+++ b/src/components/CommandReference/CommandReference.module.css
@@ -18,10 +18,10 @@
 
 .catButton {
   padding: 4px 10px;
-  border: 1px solid #45475a;
+  border: 1px solid var(--ctp-surface2);
   border-radius: 4px;
   background: transparent;
-  color: #6c7086;
+  color: var(--ctp-subtext1);
   font-size: 12px;
   cursor: pointer;
   transition:
@@ -30,7 +30,7 @@
 }
 
 .catButton:hover {
-  color: #a6adc8;
+  color: var(--ctp-text);
 }
 
 .catSelected {
@@ -39,22 +39,22 @@
 
 .search {
   padding: 6px 10px;
-  border: 1px solid #45475a;
+  border: 1px solid var(--ctp-surface2);
   border-radius: 4px;
-  background: #1e1e2e;
-  color: #cdd6f4;
+  background: var(--ctp-base);
+  color: var(--ctp-foreground);
   font-size: 13px;
   width: 180px;
   margin-left: auto;
 }
 
 .search::placeholder {
-  color: #6c7086;
+  color: var(--ctp-subtext1);
 }
 
 .search:focus {
   outline: none;
-  border-color: #89b4fa;
+  border-color: var(--ctp-blue);
 }
 
 .tableWrapper {
@@ -88,13 +88,13 @@
 .table th {
   text-align: left;
   padding: 6px 10px;
-  color: #6c7086;
+  color: var(--ctp-subtext1);
   font-weight: 500;
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  border-bottom: 1px solid #313244;
-  background: #181825;
+  border-bottom: 1px solid var(--ctp-surface1);
+  background: var(--ctp-mantle);
 }
 
 .thKey {
@@ -119,32 +119,33 @@
 
 .row td {
   padding: 5px 10px;
-  border-bottom: 1px solid rgba(69, 71, 90, 0.3);
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--ctp-surface2) 30%, transparent);
 }
 
 .cellKey {
   font-family: "JetBrains Mono", "Fira Code", monospace;
-  color: #cdd6f4;
+  color: var(--ctp-foreground);
 }
 
 .cellKey code {
-  background: #313244;
+  background: var(--ctp-surface1);
   padding: 1px 6px;
   border-radius: 3px;
   font-size: 12px;
 }
 
 .cellDiff code {
-  background: rgba(137, 180, 250, 0.15);
-  color: #89b4fa;
+  background: color-mix(in srgb, var(--ctp-blue) 15%, transparent);
+  color: var(--ctp-blue);
 }
 
 .cellName {
-  color: #a6adc8;
+  color: var(--ctp-text);
 }
 
 .cellDesc {
-  color: #7f849c;
+  color: var(--ctp-subtext0);
 }
 
 .sources {
@@ -155,10 +156,10 @@
 
 .srcButton {
   padding: 4px 10px;
-  border: 1px solid #45475a;
+  border: 1px solid var(--ctp-surface2);
   border-radius: 4px;
   background: transparent;
-  color: #6c7086;
+  color: var(--ctp-subtext1);
   font-size: 12px;
   cursor: pointer;
   transition:
@@ -167,7 +168,7 @@
 }
 
 .srcButton:hover {
-  color: #a6adc8;
+  color: var(--ctp-text);
 }
 
 .srcSelected {
@@ -186,6 +187,6 @@
 .count {
   margin-top: 12px;
   font-size: 12px;
-  color: #6c7086;
+  color: var(--ctp-subtext1);
   text-align: right;
 }

--- a/src/components/ExportPanel/ExportPanel.module.css
+++ b/src/components/ExportPanel/ExportPanel.module.css
@@ -14,7 +14,7 @@
 .tabs {
   display: flex;
   gap: 2px;
-  background: #181825;
+  background: var(--ctp-mantle);
   border-radius: 6px;
   padding: 3px;
 }
@@ -26,7 +26,7 @@
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
-  color: #6c7086;
+  color: var(--ctp-subtext1);
   background: transparent;
   transition:
     background-color 0.15s,
@@ -34,12 +34,12 @@
 }
 
 .tab:hover {
-  color: #a6adc8;
+  color: var(--ctp-text);
 }
 
 .tabActive {
-  background: #313244;
-  color: #cdd6f4;
+  background: var(--ctp-surface1);
+  color: var(--ctp-foreground);
 }
 
 .actions {
@@ -49,10 +49,10 @@
 
 .actionButton {
   padding: 4px 12px;
-  border: 1px solid #45475a;
+  border: 1px solid var(--ctp-surface2);
   border-radius: 6px;
   background: transparent;
-  color: #a6adc8;
+  color: var(--ctp-text);
   font-size: 12px;
   cursor: pointer;
   transition:
@@ -61,8 +61,8 @@
 }
 
 .actionButton:hover:not(:disabled) {
-  border-color: #89b4fa;
-  color: #89b4fa;
+  border-color: var(--ctp-blue);
+  color: var(--ctp-blue);
 }
 
 .actionButton:disabled {
@@ -71,23 +71,23 @@
 }
 
 .actionButtonSuccess {
-  border-color: #a6e3a1;
-  color: #a6e3a1;
+  border-color: var(--ctp-green);
+  color: var(--ctp-green);
 }
 
 .actionButtonError {
-  border-color: #f38ba8;
-  color: #f38ba8;
+  border-color: var(--ctp-red);
+  color: var(--ctp-red);
 }
 
 .preview {
-  background: #181825;
-  border: 1px solid #313244;
+  background: var(--ctp-mantle);
+  border: 1px solid var(--ctp-surface1);
   border-radius: 8px;
   padding: 12px 16px;
   font-family: "Courier New", Courier, monospace;
   font-size: 12px;
-  color: #cdd6f4;
+  color: var(--ctp-foreground);
   line-height: 1.6;
   overflow-x: auto;
   max-height: 300px;
@@ -98,10 +98,10 @@
 
 .empty {
   font-size: 13px;
-  color: #6c7086;
+  color: var(--ctp-subtext1);
   padding: 16px;
-  background: #181825;
-  border: 1px dashed #45475a;
+  background: var(--ctp-mantle);
+  border: 1px dashed var(--ctp-surface2);
   border-radius: 8px;
   text-align: center;
   margin: 0;

--- a/src/components/KeyCapture/KeyCapture.module.css
+++ b/src/components/KeyCapture/KeyCapture.module.css
@@ -1,8 +1,8 @@
 /* Catppuccin Mocha テーマに準拠したキーキャプチャ UI */
 
 .container {
-  background: #1e1e2e;
-  border: 1px solid #45475a;
+  background: var(--ctp-base);
+  border: 1px solid var(--ctp-surface2);
   border-radius: 8px;
   padding: 16px 20px;
   min-height: 48px;
@@ -12,12 +12,12 @@
 }
 
 .container:focus-visible {
-  outline: 2px solid #89b4fa;
+  outline: 2px solid var(--ctp-blue);
   outline-offset: 2px;
 }
 
 .placeholder {
-  color: #6c7086;
+  color: var(--ctp-subtext1);
   font-size: 14px;
 }
 
@@ -28,18 +28,18 @@
 }
 
 .keyBadge {
-  background: #313244;
-  border: 1px solid #89b4fa;
+  background: var(--ctp-surface1);
+  border: 1px solid var(--ctp-blue);
   border-radius: 4px;
   padding: 4px 10px;
   font-family: "SF Mono", monospace;
   font-size: 16px;
   font-weight: 600;
-  color: #89b4fa;
+  color: var(--ctp-blue);
   letter-spacing: 0.02em;
 }
 
 .hint {
-  color: #6c7086;
+  color: var(--ctp-subtext1);
   font-size: 12px;
 }

--- a/src/components/Keyboard/Key.module.css
+++ b/src/components/Keyboard/Key.module.css
@@ -47,23 +47,23 @@
 }
 
 .highlight_target {
-  box-shadow: 0 0 12px 4px #4fc3f7;
+  box-shadow: 0 0 12px 4px var(--ctp-cyan);
   animation: pulse 1.5s ease-in-out infinite;
   z-index: 5;
 }
 
 .highlight_correct {
-  box-shadow: 0 0 12px 4px #a6e3a1;
+  box-shadow: 0 0 12px 4px var(--ctp-green);
   z-index: 5;
 }
 
 .highlight_incorrect {
-  box-shadow: 0 0 12px 4px #f38ba8;
+  box-shadow: 0 0 12px 4px var(--ctp-red);
   z-index: 5;
 }
 
 .highlight_modifier {
-  box-shadow: 0 0 12px 4px #fab387;
+  box-shadow: 0 0 12px 4px var(--ctp-peach);
   animation: pulse_mod 1.5s ease-in-out infinite;
   z-index: 5;
 }
@@ -71,19 +71,19 @@
 @keyframes pulse {
   0%,
   100% {
-    box-shadow: 0 0 8px 2px #4fc3f7;
+    box-shadow: 0 0 8px 2px var(--ctp-cyan);
   }
   50% {
-    box-shadow: 0 0 16px 6px #4fc3f7;
+    box-shadow: 0 0 16px 6px var(--ctp-cyan);
   }
 }
 
 @keyframes pulse_mod {
   0%,
   100% {
-    box-shadow: 0 0 8px 2px #fab387;
+    box-shadow: 0 0 8px 2px var(--ctp-peach);
   }
   50% {
-    box-shadow: 0 0 16px 6px #fab387;
+    box-shadow: 0 0 16px 6px var(--ctp-peach);
   }
 }

--- a/src/components/LayoutLoader/LayoutLoader.module.css
+++ b/src/components/LayoutLoader/LayoutLoader.module.css
@@ -15,14 +15,14 @@
 .label {
   font-size: 12px;
   font-weight: 600;
-  color: #a6adc8;
+  color: var(--ctp-text);
 }
 
 .dropzone {
-  border: 2px dashed #45475a;
+  border: 2px dashed var(--ctp-surface2);
   border-radius: 8px;
   padding: 12px 16px;
-  color: #6c7086;
+  color: var(--ctp-subtext1);
   font-size: 13px;
   cursor: pointer;
   transition:
@@ -33,25 +33,25 @@
 
 .dropzone:hover,
 .dropzoneActive {
-  border-color: #89b4fa;
-  color: #89b4fa;
+  border-color: var(--ctp-blue);
+  color: var(--ctp-blue);
 }
 
 .fileName {
-  color: #a6e3a1;
+  color: var(--ctp-green);
   font-weight: 500;
 }
 
 .error {
-  color: #f38ba8;
+  color: var(--ctp-red);
   font-size: 12px;
 }
 
 .clearButton {
   background: none;
-  border: 1px solid #45475a;
+  border: 1px solid var(--ctp-surface2);
   border-radius: 6px;
-  color: #6c7086;
+  color: var(--ctp-subtext1);
   font-size: 12px;
   padding: 4px 12px;
   cursor: pointer;
@@ -62,8 +62,8 @@
 }
 
 .clearButton:hover {
-  border-color: #f38ba8;
-  color: #f38ba8;
+  border-color: var(--ctp-red);
+  color: var(--ctp-red);
 }
 
 .keymapGroup {
@@ -75,11 +75,11 @@
 }
 
 .presetSelect {
-  background: #1e1e2e;
-  border: 2px solid #45475a;
+  background: var(--ctp-base);
+  border: 2px solid var(--ctp-surface2);
   border-radius: 8px;
   padding: 8px 12px;
-  color: #cdd6f4;
+  color: var(--ctp-foreground);
   font-size: 13px;
   cursor: pointer;
   transition:
@@ -91,6 +91,6 @@
 
 .presetSelect:hover,
 .presetSelect:focus {
-  border-color: #89b4fa;
+  border-color: var(--ctp-blue);
   outline: none;
 }

--- a/src/components/ModeSelector/ModeSelector.module.css
+++ b/src/components/ModeSelector/ModeSelector.module.css
@@ -6,14 +6,14 @@
 
 .label {
   font-size: 11px;
-  color: #6c7086;
+  color: var(--ctp-subtext1);
   white-space: nowrap;
 }
 
 .tabs {
   display: flex;
   gap: 2px;
-  background: #181825;
+  background: var(--ctp-mantle);
   border-radius: 6px;
   padding: 2px;
 }
@@ -25,7 +25,7 @@
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
-  color: #6c7086;
+  color: var(--ctp-subtext1);
   background: transparent;
   transition:
     background-color 0.15s,
@@ -33,12 +33,12 @@
 }
 
 .tab:hover {
-  color: #a6adc8;
+  color: var(--ctp-text);
 }
 
 .tabActive {
-  background: #313244;
-  color: #cdd6f4;
+  background: var(--ctp-surface1);
+  color: var(--ctp-foreground);
 }
 
 .short {

--- a/src/components/PracticeMode/PracticePrompt.module.css
+++ b/src/components/PracticeMode/PracticePrompt.module.css
@@ -1,6 +1,6 @@
 .panel {
-  background: #1e1e2e;
-  border: 1px solid #313244;
+  background: var(--ctp-base);
+  border: 1px solid var(--ctp-surface1);
   border-radius: 8px;
   padding: 16px 20px;
   text-align: center;
@@ -8,11 +8,11 @@
 }
 
 .panel.correct {
-  border-color: #a6e3a1;
+  border-color: var(--ctp-green);
 }
 
 .panel.incorrect {
-  border-color: #f38ba8;
+  border-color: var(--ctp-red);
 }
 
 .prompt {
@@ -35,7 +35,7 @@
 .hint {
   font-size: 15px;
   font-weight: 600;
-  color: #fab387;
+  color: var(--ctp-peach);
   font-family: "SF Mono", "Fira Code", monospace;
 }
 
@@ -49,17 +49,17 @@
 .commandName {
   font-size: 20px;
   font-weight: 700;
-  color: #cdd6f4;
+  color: var(--ctp-foreground);
 }
 
 .description {
   font-size: 14px;
-  color: #a6adc8;
+  color: var(--ctp-text);
 }
 
 .instruction {
   font-size: 14px;
-  color: #6c7086;
+  color: var(--ctp-subtext1);
 }
 
 .score {
@@ -68,27 +68,27 @@
   justify-content: center;
   gap: 8px;
   font-size: 13px;
-  color: #a6adc8;
+  color: var(--ctp-text);
 }
 
 .rate {
-  color: #6c7086;
+  color: var(--ctp-subtext1);
 }
 
 .streak {
-  color: #f9e2af;
+  color: var(--ctp-yellow);
   font-weight: 600;
 }
 
 .message {
-  color: #6c7086;
+  color: var(--ctp-subtext1);
   font-size: 14px;
 }
 
 .startButton {
-  background: #4fc3f733;
-  border: 1px solid #4fc3f7;
-  color: #4fc3f7;
+  background: color-mix(in srgb, var(--ctp-cyan) 20%, transparent);
+  border: 1px solid var(--ctp-cyan);
+  color: var(--ctp-cyan);
   padding: 8px 24px;
   border-radius: 6px;
   font-size: 14px;
@@ -98,5 +98,5 @@
 }
 
 .startButton:hover {
-  background: #4fc3f755;
+  background: color-mix(in srgb, var(--ctp-cyan) 33%, transparent);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,22 @@
+:root {
+  --ctp-crust: #11111b;
+  --ctp-mantle: #181825;
+  --ctp-base: #1e1e2e;
+  --ctp-surface0: #24273a;
+  --ctp-surface1: #313244;
+  --ctp-surface2: #45475a;
+  --ctp-subtext0: #7f849c;
+  --ctp-subtext1: #6c7086;
+  --ctp-text: #a6adc8;
+  --ctp-foreground: #cdd6f4;
+  --ctp-blue: #89b4fa;
+  --ctp-cyan: #4fc3f7;
+  --ctp-green: #a6e3a1;
+  --ctp-red: #f38ba8;
+  --ctp-peach: #fab387;
+  --ctp-yellow: #f9e2af;
+}
+
 *,
 *::before,
 *::after {
@@ -9,8 +28,8 @@
 body {
   font-family:
     "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background: #11111b;
-  color: #cdd6f4;
+  background: var(--ctp-crust);
+  color: var(--ctp-foreground);
   min-height: 100vh;
 }
 


### PR DESCRIPTION
## Summary
- `:root` に Catppuccin Mocha 16 色の CSS カスタムプロパティ (`--ctp-*`) を定義
- 11 の CSS ファイルからハードコードされた色値を `var()` 参照に置換（約 140 箇所）
- `rgba()` 表現を `color-mix()` に変換してカスタムプロパティベースに統一
- CSS カスタムプロパティの定義・排除を検証する統合テストを追加（38 テスト）

Closes #98

## Test plan
- [x] 全 38 テスト PASS（CSS カスタムプロパティ定義・ハードコード排除検証）
- [x] 既存テスト全 573 件 PASS
- [x] Biome check PASS
- [x] `tsc --noEmit` PASS
- [x] `pnpm build` PASS
- [ ] ブラウザでビジュアル変化がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)