### PR TITLE
docs: escapeLua / escapeLangmapChar に JSDoc で用途を明示

### DIFF
--- a/src/utils/keybinding-exporters.ts
+++ b/src/utils/keybinding-exporters.ts
@@ -3,6 +3,10 @@ import type { KeybindingConfig, VimMode } from "../types/keybinding";
 
 const VIM_MODES: VimMode[] = ["n", "v", "x", "o", "i", "s", "c", "t"];
 
+/**
+ * Lua 文字列リテラル用エスケープ。
+ * `\` と `"` を対象とし、`vim.keymap.set()` の引数として使用される。
+ */
 function escapeLua(str: string): string {
   return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
@@ -35,6 +39,10 @@ export function keybindingToJSON(config: KeybindingConfig): string {
   return JSON.stringify(config, null, 2);
 }
 
+/**
+ * Vim `langmap` オプション用エスケープ。
+ * `\`, `,`, `;`, `"` の 4 文字を対象とし、`vim.opt.langmap` の値として使用される。
+ */
 function escapeLangmapChar(char: string): string {
   return char.replace(/[\\,;"]/g, (c) => `\\${c}`);
 }


### PR DESCRIPTION
## Summary
- `escapeLua` に Lua 文字列リテラル用エスケープである旨の JSDoc を追加
- `escapeLangmapChar` に Vim `langmap` オプション用エスケープである旨の JSDoc を追加

Closes #170

## Test plan
- [x] 既存テスト 630 件全て通過
- [x] Biome lint 通過
- [x] ビルド通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)