### PR TITLE
refactor: isVIADefinition の as Record 型アサーションを除去

### DIFF
--- a/src/utils/kle-parser.ts
+++ b/src/utils/kle-parser.ts
@@ -139,21 +139,13 @@ export function parseVIAorKLE(json: unknown): KeyboardLayout {
 }
 
 export function isVIADefinition(json: unknown): json is VIADefinition {
-  return (
-    typeof json === "object" &&
-    json !== null &&
-    "name" in json &&
-    typeof (json as Record<string, unknown>).name === "string" &&
-    "layouts" in json &&
-    typeof (json as Record<string, unknown>).layouts === "object" &&
-    (json as Record<string, unknown>).layouts !== null &&
-    "keymap" in
-      ((json as Record<string, unknown>).layouts as Record<string, unknown>) &&
-    isKLEJSON(
-      ((json as Record<string, unknown>).layouts as Record<string, unknown>)
-        .keymap,
-    )
-  );
+  if (typeof json !== "object" || json === null) return false;
+  if (!("name" in json) || typeof json.name !== "string") return false;
+  if (!("layouts" in json)) return false;
+  const layouts = json.layouts;
+  if (typeof layouts !== "object" || layouts === null) return false;
+  if (!("keymap" in layouts)) return false;
+  return isKLEJSON(layouts.keymap);
 }
 
 export function isKLEJSON(json: unknown): json is KLEJSON {


### PR DESCRIPTION
## Summary
- `isVIADefinition` 内の `as Record<string, unknown>` を全て除去
- `in` 演算子による TypeScript narrowing を活用し、早期リターンスタイルに書き換え
- 振る舞いの変更なし（リファクタリングのみ）

Closes #168

## Test plan
- [x] 既存テスト 21 件（isVIADefinition）が全て PASS
- [x] 全テスト 630 件 PASS
- [x] Biome check PASS
- [x] tsc --noEmit PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)