### PR TITLE
fix: worktree の pnpm safe-chain EPERM を回避

### DIFF
--- a/.claude/agents/implement.md
+++ b/.claude/agents/implement.md
@@ -44,10 +44,11 @@ model: sonnet
 
 ## フォーマット自動修正
 
-実装が完了したら、完了報告の前に `pnpm lint:fix` を実行してください。
+実装が完了したら、完了報告の前に lint:fix を実行してください。worktree 環境では safe-chain ラッパーが sandbox で動作しないため、pnpm パスを自動解決する:
 
 ```bash
-pnpm lint:fix
+PNPM=$( [ "$(git rev-parse --git-common-dir 2>/dev/null)" != ".git" ] && echo /etc/profiles/per-user/shiroino/bin/pnpm || echo pnpm )
+$PNPM lint:fix
 ```
 
 - Biome が自動修正可能な違反（import 順序、テンプレートリテラル推奨、行長制限など）を修正します

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -17,14 +17,19 @@ TDD のテスト実行と**状態判定**を担当するエージェントです
 
 ## テスト実行コマンド
 
+worktree 環境では safe-chain ラッパーが sandbox で動作しないため、pnpm パスを自動解決する。**全コマンドの先頭に以下を付与すること**:
+```bash
+PNPM=$( [ "$(git rev-parse --git-common-dir 2>/dev/null)" != ".git" ] && echo /etc/profiles/per-user/shiroino/bin/pnpm || echo pnpm )
+```
+
 ### 全テスト実行
 ```bash
-pnpm test
+$PNPM test
 ```
 
 ### 特定ファイルのみ実行
 ```bash
-pnpm vitest run src/utils/calculator.test.ts
+$PNPM vitest run src/utils/calculator.test.ts
 ```
 
 ## 状態判定ロジック

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -75,10 +75,11 @@ describe('targetFunction', () => {
 
 ## フォーマット自動修正
 
-テストファイルの作成が完了したら、`pnpm lint:fix` を実行してください。
+テストファイルの作成が完了したら、lint:fix を実行してください。worktree 環境では safe-chain ラッパーが sandbox で動作しないため、pnpm パスを自動解決する:
 
 ```bash
-pnpm lint:fix
+PNPM=$( [ "$(git rev-parse --git-common-dir 2>/dev/null)" != ".git" ] && echo /etc/profiles/per-user/shiroino/bin/pnpm || echo pnpm )
+$PNPM lint:fix
 ```
 
 - Biome が自動修正可能な違反（import 順序、テンプレートリテラル推奨、行長制限など）を修正します

--- a/.claude/skills/local-ci/SKILL.md
+++ b/.claude/skills/local-ci/SKILL.md
@@ -11,10 +11,10 @@ user-invocable: true
 ## 実行手順
 
 1. 開始メッセージを表示: `Local CI を実行します...`
-2. 以下の 3 コマンドを **並列に Bash ツールで実行**（1 メッセージで 3 つの Bash tool call を送る）:
-   - `pnpm lint`
-   - `pnpm test`
-   - `pnpm build`
+2. 以下の 3 コマンドを **並列に Bash ツールで実行**（1 メッセージで 3 つの Bash tool call を送る）。各コマンドの先頭に worktree 検出の pnpm パス解決を付与する:
+   - `PNPM=$( [ "$(git rev-parse --git-common-dir 2>/dev/null)" != ".git" ] && echo /etc/profiles/per-user/shiroino/bin/pnpm || echo pnpm ) && $PNPM lint`
+   - `PNPM=$( [ "$(git rev-parse --git-common-dir 2>/dev/null)" != ".git" ] && echo /etc/profiles/per-user/shiroino/bin/pnpm || echo pnpm ) && $PNPM test`
+   - `PNPM=$( [ "$(git rev-parse --git-common-dir 2>/dev/null)" != ".git" ] && echo /etc/profiles/per-user/shiroino/bin/pnpm || echo pnpm ) && $PNPM build`
 3. 各コマンドの **exit code** で PASS/FAIL を判定
 4. 結果をサマリーとして表示
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,18 @@ VIA キーマップ読み込み時:
 2. 出力文字 → `invertKeymap()` で QWERTY 位置に逆引き（= langmap と同等の変換）
 3. QWERTY 位置 → Vim コマンドを引き当て
 
+## Worktree 環境での pnpm
+
+Worktree エージェント（sandbox 内）では `pnpm` シェル関数（safe-chain ラッパー）がプロキシサーバーの listen で EPERM になる。スキル・エージェントでは以下のワンライナーで worktree を検出し、直接バイナリにフォールバックする:
+
+```bash
+PNPM=$( [ "$(git rev-parse --git-common-dir 2>/dev/null)" != ".git" ] && echo /etc/profiles/per-user/shiroino/bin/pnpm || echo pnpm )
+$PNPM lint
+```
+
+- メインセッション（`.git` がディレクトリ）: `pnpm`（safe-chain 経由）
+- Worktree（`.git` がファイル）: Nix の pnpm バイナリを直接使用
+
 ## ロードマップ
 
 [ROADMAP.md](./ROADMAP.md) を参照。


### PR DESCRIPTION
## Summary

- worktree エージェントで `pnpm` (safe-chain ラッパー) がプロキシサーバーの `listen 0.0.0.0` で EPERM になる問題を回避
- `git rev-parse --git-common-dir` で worktree を検出し、Nix の pnpm バイナリに直接フォールバック
- メインセッションでは従来通り safe-chain 経由の pnpm を使用

## Test plan

- [x] worktree で `$PNPM lint` 成功
- [x] worktree で `$PNPM test` 成功（632 tests passed）
- [x] worktree で `$PNPM build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #161