### PR TITLE
feat: Vial HID 通信にタイムアウト機構を追加

### DIFF
--- a/src/utils/vial-protocol.test.ts
+++ b/src/utils/vial-protocol.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { VialDevice } from "../types/vial";
 import {
+  COMMAND_TIMEOUT_MS,
   connectVialDevice,
   disconnectVialDevice,
   getKeyboardDefinition,
@@ -652,5 +653,68 @@ describe("getKeymapData", () => {
         expect(typeof key).toBe("string");
       }
     }
+  });
+});
+
+// ============================================================
+// sendCommand タイムアウト（getKeymapData 経由）
+// ============================================================
+
+describe("sendCommand タイムアウト", () => {
+  it("デバイスが応答しない場合、COMMAND_TIMEOUT_MS 経過後に reject される", async () => {
+    vi.useFakeTimers();
+
+    const mockDevice = createMockHIDDevice();
+
+    // sendReport は成功するが inputreport イベントを発火しない（デバイスが無応答）
+    mockDevice.sendReport.mockResolvedValue(undefined);
+
+    const vialDevice: VialDevice = {
+      hid: mockDevice as unknown as HIDDevice,
+      productName: "Test Vial Keyboard",
+    };
+
+    const promise = getKeymapData(vialDevice, 1, 4);
+    // advanceTimersByTimeAsync 中に reject が発生するため、先にハンドラを登録して unhandled rejection を防ぐ
+    const assertion = expect(promise).rejects.toThrow();
+
+    // COMMAND_TIMEOUT_MS（5000ms）を超える時間を経過させる
+    await vi.advanceTimersByTimeAsync(COMMAND_TIMEOUT_MS + 1);
+
+    await assertion;
+
+    vi.useRealTimers();
+  });
+
+  it("タイムアウト時に removeEventListener が呼ばれてリスナーがクリーンアップされる", async () => {
+    vi.useFakeTimers();
+
+    const mockDevice = createMockHIDDevice();
+
+    // sendReport は成功するが inputreport イベントを発火しない（デバイスが無応答）
+    mockDevice.sendReport.mockResolvedValue(undefined);
+
+    const vialDevice: VialDevice = {
+      hid: mockDevice as unknown as HIDDevice,
+      productName: "Test Vial Keyboard",
+    };
+
+    const promise = getKeymapData(vialDevice, 1, 4);
+    // advanceTimersByTimeAsync 中に reject が発生するため、先にハンドラを登録して unhandled rejection を防ぐ
+    const assertion = expect(promise).rejects.toThrow();
+
+    // タイムアウトを超える時間を経過させる
+    await vi.advanceTimersByTimeAsync(COMMAND_TIMEOUT_MS + 1);
+
+    // reject されることを確認（クリーンアップ後の状態検証のため先に待つ）
+    await assertion;
+
+    // タイムアウト時に addEventListener で登録したハンドラが removeEventListener で解除されること
+    expect(mockDevice.removeEventListener).toHaveBeenCalledWith(
+      "inputreport",
+      expect.any(Function),
+    );
+
+    vi.useRealTimers();
   });
 });

--- a/src/utils/vial-protocol.ts
+++ b/src/utils/vial-protocol.ts
@@ -17,6 +17,8 @@ const DYNAMIC_KEYMAP_GET_BUFFER = 0x12;
 const HID_REPORT_SIZE = 32;
 // ヘッダバイト数（コマンド2バイト + offset 2バイト or offset 2 + size 1）
 const CHUNK_SIZE = 28;
+// inputreport 応答待ちのタイムアウト時間（ミリ秒）
+export const COMMAND_TIMEOUT_MS = 5000;
 
 // USB HID Usage Table に準拠した QMK キーコード → キーコード文字列マッピング
 const QMK_KEYCODE_MAP: Record<number, string> = {
@@ -103,19 +105,36 @@ export function isWebHIDSupported(): boolean {
 /**
  * HID コマンドを送信して inputreport イベントで応答を待つ
  * sendReport が reject した場合はエラーを伝播させる
+ * COMMAND_TIMEOUT_MS 以内に inputreport が発火しない場合は reject する
  */
-async function sendCommand(
-  device: VialDevice,
-  data: Uint8Array,
-): Promise<DataView> {
-  return new Promise((resolve, reject) => {
+function sendCommand(device: VialDevice, data: Uint8Array): Promise<DataView> {
+  return new Promise<DataView>((resolve, reject) => {
+    let settled = false;
+
+    // タイムアウト ID を保持して応答受信時にキャンセルできるようにする
+    const timeoutId = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      // タイムアウト時はリスナーをクリーンアップしてから reject
+      device.hid.removeEventListener("inputreport", handler);
+      reject(new Error(`HID command timed out after ${COMMAND_TIMEOUT_MS}ms`));
+    }, COMMAND_TIMEOUT_MS);
+
     const handler = (event: HIDInputReportEvent) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
       device.hid.removeEventListener("inputreport", handler);
       resolve(event.data);
     };
+
     device.hid.addEventListener("inputreport", handler);
+
     // sendReport の失敗を Promise の reject に伝播させる
     Promise.resolve(device.hid.sendReport(0x00, data)).catch((err: unknown) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
       device.hid.removeEventListener("inputreport", handler);
       reject(err);
     });


### PR DESCRIPTION
## Summary
- `sendCommand` に `COMMAND_TIMEOUT_MS`（5000ms）のタイムアウト機構を追加。`settled` フラグで3経路（タイムアウト/正常応答/sendReport エラー）の競合状態を防止
- タイムアウト時は `inputreport` リスナーをクリーンアップしてから reject
- タイムアウト検証テスト2件を追加（`vi.useFakeTimers` 使用）

Closes #162

## Test plan
- [x] タイムアウト後に reject されることを検証
- [x] タイムアウト時に `removeEventListener` が呼ばれることを検証
- [x] 既存テスト 21件が引き続きパス（計 634 tests all passed）
- [x] Local CI: Biome / Test / Build 全て PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)