### PR TITLE
fix: epic-auto-done で sub-issues の parent API を使用

### DIFF
--- a/.github/workflows/epic-auto-done.yml
+++ b/.github/workflows/epic-auto-done.yml
@@ -31,9 +31,7 @@ jobs:
               repository(owner: $owner, name: $repo) {
                 issue(number: $number) {
                   parent {
-                    ... on Issue {
-                      number
-                    }
+                    number
                   }
                 }
               }


### PR DESCRIPTION
## Summary
- `trackedInIssues`（旧タスクリスト追跡 API）→ `parent`（sub-issues 機能の API）に切り替え
- sub-issues 機能では `trackedInIssues` に親が返らないため、ワークフローの Step 2 が常に skip されていた
- 単一親のためループ構造を除去しシンプル化

## Test plan
- [ ] sub-issue を持つ epic の最後の sub-issue を close し、epic が Done に移動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)