### PR TITLE
refactor: モード別表示制御条件を定数セットに集約

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,15 @@ import {
 import { useKeyboardLayout } from "./hooks/useKeyboardLayout";
 import { useNvimMaps } from "./hooks/useNvimMaps";
 import type { AppMode, KeybindingConfig, VimMode } from "./types/keybinding";
-import { APP_MODE_LABELS, APP_MODES } from "./types/keybinding";
+import {
+  APP_MODE_LABELS,
+  APP_MODES,
+  HIGHLIGHT_MODES,
+  KEYBOARD_HIDDEN_MODES,
+  KEYBOARD_PLAIN_MODES,
+  LEGEND_HIDDEN_MODES,
+  MODE_SELECTOR_VISIBLE_MODES,
+} from "./types/keybinding";
 import type { HighlightEntry, VIAKeymapFull, VimCommand } from "./types/vim";
 import { mergeWithNvimMaps } from "./utils/merge-vim-commands";
 import {
@@ -214,7 +222,7 @@ function AppContent() {
                 </button>
               ))}
             </div>
-            {(mode === "visualize" || mode === "reference") && (
+            {MODE_SELECTOR_VISIBLE_MODES.has(mode) && (
               <ModeSelector
                 activeMode={activeVimMode}
                 onModeChange={setActiveVimMode}
@@ -254,7 +262,7 @@ function AppContent() {
         </div>
       )}
 
-      {mode !== "edit" && (
+      {!KEYBOARD_HIDDEN_MODES.has(mode) && (
         <div
           className={`${styles.keyboardWrapper} ${mode === "reference" ? styles.keyboardSticky : ""}`}
         >
@@ -264,15 +272,9 @@ function AppContent() {
             matrixKeymap={activeMatrixKeymap}
             onHover={mode === "visualize" ? handleHover : noopHover}
             highlightKeys={
-              mode === "practice" || mode === "reference"
-                ? highlightKeys
-                : undefined
+              HIGHLIGHT_MODES.has(mode) ? highlightKeys : undefined
             }
-            plain={
-              mode === "practice" ||
-              mode === "reference" ||
-              mode === "keymap-edit"
-            }
+            plain={KEYBOARD_PLAIN_MODES.has(mode)}
             activeVimMode={activeVimMode}
           />
         </div>
@@ -317,7 +319,7 @@ function AppContent() {
         </div>
       )}
 
-      {mode !== "edit" && mode !== "keymap-edit" && (
+      {!LEGEND_HIDDEN_MODES.has(mode) && (
         <div className={styles.legend} data-testid="legend">
           {Object.entries(categoryColors).map(([cat, color]) => (
             <div key={cat} className={styles.legendItem}>

--- a/src/types/keybinding.test.ts
+++ b/src/types/keybinding.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, test } from "vitest";
 import type { AppMode, KeybindingSource } from "./keybinding";
-import { APP_MODE_LABELS, APP_MODES, KEYBINDING_SOURCES } from "./keybinding";
+import {
+  APP_MODE_LABELS,
+  APP_MODES,
+  HIGHLIGHT_MODES,
+  KEYBINDING_SOURCES,
+  KEYBOARD_HIDDEN_MODES,
+  KEYBOARD_PLAIN_MODES,
+  LEGEND_HIDDEN_MODES,
+  MODE_SELECTOR_VISIBLE_MODES,
+} from "./keybinding";
 
 describe("APP_MODES", () => {
   test("5つの要素を持つ", () => {
@@ -69,6 +78,141 @@ describe("APP_MODE_LABELS", () => {
 
     test.each(cases)('"%s" のラベルは "%s"', (mode, expected) => {
       expect(APP_MODE_LABELS[mode]).toBe(expected);
+    });
+  });
+});
+
+describe("KEYBOARD_HIDDEN_MODES", () => {
+  test("Set のインスタンスである", () => {
+    expect(KEYBOARD_HIDDEN_MODES).toBeInstanceOf(Set);
+  });
+
+  test("サイズが 1 である", () => {
+    expect(KEYBOARD_HIDDEN_MODES.size).toBe(1);
+  });
+
+  describe("含まれるべきモード", () => {
+    const included: AppMode[] = ["edit"];
+
+    test.each(included)('"%s" を含む', (mode) => {
+      expect(KEYBOARD_HIDDEN_MODES.has(mode)).toBe(true);
+    });
+  });
+
+  describe("含まれるべきでないモード", () => {
+    const excluded: AppMode[] = [
+      "visualize",
+      "practice",
+      "reference",
+      "keymap-edit",
+    ];
+
+    test.each(excluded)('"%s" を含まない', (mode) => {
+      expect(KEYBOARD_HIDDEN_MODES.has(mode)).toBe(false);
+    });
+  });
+});
+
+describe("LEGEND_HIDDEN_MODES", () => {
+  test("Set のインスタンスである", () => {
+    expect(LEGEND_HIDDEN_MODES).toBeInstanceOf(Set);
+  });
+
+  test("サイズが 2 である", () => {
+    expect(LEGEND_HIDDEN_MODES.size).toBe(2);
+  });
+
+  describe("含まれるべきモード", () => {
+    const included: AppMode[] = ["edit", "keymap-edit"];
+
+    test.each(included)('"%s" を含む', (mode) => {
+      expect(LEGEND_HIDDEN_MODES.has(mode)).toBe(true);
+    });
+  });
+
+  describe("含まれるべきでないモード", () => {
+    const excluded: AppMode[] = ["visualize", "practice", "reference"];
+
+    test.each(excluded)('"%s" を含まない', (mode) => {
+      expect(LEGEND_HIDDEN_MODES.has(mode)).toBe(false);
+    });
+  });
+});
+
+describe("KEYBOARD_PLAIN_MODES", () => {
+  test("Set のインスタンスである", () => {
+    expect(KEYBOARD_PLAIN_MODES).toBeInstanceOf(Set);
+  });
+
+  test("サイズが 3 である", () => {
+    expect(KEYBOARD_PLAIN_MODES.size).toBe(3);
+  });
+
+  describe("含まれるべきモード", () => {
+    const included: AppMode[] = ["practice", "reference", "keymap-edit"];
+
+    test.each(included)('"%s" を含む', (mode) => {
+      expect(KEYBOARD_PLAIN_MODES.has(mode)).toBe(true);
+    });
+  });
+
+  describe("含まれるべきでないモード", () => {
+    const excluded: AppMode[] = ["visualize", "edit"];
+
+    test.each(excluded)('"%s" を含まない', (mode) => {
+      expect(KEYBOARD_PLAIN_MODES.has(mode)).toBe(false);
+    });
+  });
+});
+
+describe("MODE_SELECTOR_VISIBLE_MODES", () => {
+  test("Set のインスタンスである", () => {
+    expect(MODE_SELECTOR_VISIBLE_MODES).toBeInstanceOf(Set);
+  });
+
+  test("サイズが 2 である", () => {
+    expect(MODE_SELECTOR_VISIBLE_MODES.size).toBe(2);
+  });
+
+  describe("含まれるべきモード", () => {
+    const included: AppMode[] = ["visualize", "reference"];
+
+    test.each(included)('"%s" を含む', (mode) => {
+      expect(MODE_SELECTOR_VISIBLE_MODES.has(mode)).toBe(true);
+    });
+  });
+
+  describe("含まれるべきでないモード", () => {
+    const excluded: AppMode[] = ["practice", "edit", "keymap-edit"];
+
+    test.each(excluded)('"%s" を含まない', (mode) => {
+      expect(MODE_SELECTOR_VISIBLE_MODES.has(mode)).toBe(false);
+    });
+  });
+});
+
+describe("HIGHLIGHT_MODES", () => {
+  test("Set のインスタンスである", () => {
+    expect(HIGHLIGHT_MODES).toBeInstanceOf(Set);
+  });
+
+  test("サイズが 2 である", () => {
+    expect(HIGHLIGHT_MODES.size).toBe(2);
+  });
+
+  describe("含まれるべきモード", () => {
+    const included: AppMode[] = ["practice", "reference"];
+
+    test.each(included)('"%s" を含む', (mode) => {
+      expect(HIGHLIGHT_MODES.has(mode)).toBe(true);
+    });
+  });
+
+  describe("含まれるべきでないモード", () => {
+    const excluded: AppMode[] = ["visualize", "edit", "keymap-edit"];
+
+    test.each(excluded)('"%s" を含まない', (mode) => {
+      expect(HIGHLIGHT_MODES.has(mode)).toBe(false);
     });
   });
 });

--- a/src/types/keybinding.ts
+++ b/src/types/keybinding.ts
@@ -41,6 +41,25 @@ export const APP_MODE_LABELS: Record<AppMode, string> = {
   "keymap-edit": "配列編集",
 };
 
+export const KEYBOARD_HIDDEN_MODES: ReadonlySet<AppMode> = new Set(["edit"]);
+export const LEGEND_HIDDEN_MODES: ReadonlySet<AppMode> = new Set([
+  "edit",
+  "keymap-edit",
+]);
+export const KEYBOARD_PLAIN_MODES: ReadonlySet<AppMode> = new Set([
+  "practice",
+  "reference",
+  "keymap-edit",
+]);
+export const MODE_SELECTOR_VISIBLE_MODES: ReadonlySet<AppMode> = new Set([
+  "visualize",
+  "reference",
+]);
+export const HIGHLIGHT_MODES: ReadonlySet<AppMode> = new Set([
+  "practice",
+  "reference",
+]);
+
 /** バインディングの出自 */
 export type KeybindingSource =
   | "default"


### PR DESCRIPTION
## Summary
- `src/types/keybinding.ts` に `KEYBOARD_HIDDEN_MODES` / `LEGEND_HIDDEN_MODES` / `KEYBOARD_PLAIN_MODES` / `MODE_SELECTOR_VISIBLE_MODES` / `HIGHLIGHT_MODES` の 5 つの `ReadonlySet<AppMode>` 定数を追加
- `src/App.tsx` の複合モード条件（`||` / `&&` チェーン）を `.has(mode)` 呼び出しに置換
- 定数セットのユニットテスト 35 ケースを追加（TDD test-first で作成）

## Test plan
- [x] 新規定数セットのユニットテスト 35 ケース全て PASS
- [x] 既存テスト 704 件全て PASS
- [x] Biome lint PASS
- [x] TypeScript 型チェック PASS
- [x] プロダクションビルド成功

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)