### PR TITLE
fix: スキル定義の gh コマンド失敗パターン3件を修正

### DIFF
--- a/.claude/skills/pr-watch/SKILL.md
+++ b/.claude/skills/pr-watch/SKILL.md
@@ -54,11 +54,11 @@ BRANCH=$(echo "$PR_INFO" | jq -r '.headRefName')
 ```bash
 # ブランチの全ワークフロー実行を取得（--limit 1 だと一部のワークフローを見落とす）
 gh run list --branch "$BRANCH" --json databaseId,name,status,conclusion \
-  --jq '[.[] | select(.status != "completed")]'
+  --jq '[.[] | select(.status == "completed" | not)]'
 
 # 全ワークフローの完了を待機（それぞれ --exit-status で成否を確認）
 for RUN_ID in $(gh run list --branch "$BRANCH" --json databaseId,status \
-  --jq '[.[] | select(.status != "completed")] | .[].databaseId'); do
+  --jq '[.[] | select(.status == "completed" | not)] | .[].databaseId'); do
   gh run watch "$RUN_ID" --exit-status
 done
 ```
@@ -67,8 +67,8 @@ done
 
 **CI 失敗時**:
 ```bash
-# 失敗ログを取得・分析（サンドボックス環境では GH_CACHE_DIR を $TMPDIR に変更）
-GH_CACHE_DIR=$TMPDIR gh run view "$RUN_ID" --log-failed
+# 失敗ログを取得・分析（サンドボックス環境では XDG_CACHE_HOME を $TMPDIR に変更）
+XDG_CACHE_HOME=$TMPDIR gh run view "$RUN_ID" --log-failed
 ```
 
 1. エラーログを分析
@@ -86,9 +86,9 @@ GH_CACHE_DIR=$TMPDIR gh run view "$RUN_ID" --log-failed
 
 ```bash
 gh api graphql -f query='
-  query($owner: String!, $repo: String!, $number: Int!) {
-    repository(owner: $owner, name: $repo) {
-      pullRequest(number: $number) {
+  query {
+    repository(owner: "shiroinock", name: "nv-atlas") {
+      pullRequest(number: '"$PR_NUMBER"') {
         reviewThreads(first: 100) {
           nodes {
             id
@@ -108,7 +108,7 @@ gh api graphql -f query='
         }
       }
     }
-  }' -f owner="shiroinock" -f repo="nv-atlas" -F number="$PR_NUMBER" \
+  }' \
   --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isOutdated == false and .isResolved == false)'
 ```
 

--- a/.claude/skills/tdd-next/SKILL.md
+++ b/.claude/skills/tdd-next/SKILL.md
@@ -50,14 +50,14 @@ gh pr checks {番号} --watch --fail-fast
 
 #### CI 失敗時のログ取得
 
-サンドボックス環境では `gh` のキャッシュディレクトリ（`~/.cache/gh/`）への書き込みが制限される。`GH_CACHE_DIR` を `$TMPDIR`（サンドボックス許可ディレクトリ）に変更して回避する:
+サンドボックス環境では `gh` のキャッシュディレクトリ（`~/.cache/gh/`）への書き込みが制限される。`XDG_CACHE_HOME` を `$TMPDIR`（サンドボックス許可ディレクトリ）に変更して回避する:
 
 ```bash
 # Run ID を取得
 RUN_ID=$(gh run list --branch {ブランチ名} --limit 1 --json databaseId,status -q '.[0].databaseId')
 
-# 失敗ログを取得（キャッシュ先をサンドボックス許可ディレクトリに変更）
-GH_CACHE_DIR=$TMPDIR gh run view "$RUN_ID" --log-failed
+# 失敗ログを取得（XDG_CACHE_HOME でキャッシュ先をサンドボックス許可ディレクトリに変更）
+XDG_CACHE_HOME=$TMPDIR gh run view "$RUN_ID" --log-failed
 ```
 
 #### アンチパターン: `gh api .../logs` を使わない


### PR DESCRIPTION
## Summary

Closes #201

トランスクリプト解析で特定された gh コマンドの反復的失敗パターン3件をスキル定義で修正。

- **パターン1**: `pr-watch` の GraphQL クエリで `$owner`/`$repo`/`$number` がシェル変数として展開される問題 → インライン値パターンに変更
- **パターン2**: `pr-watch` の jq 式 `\!=` が zsh ヒストリ展開で `\\\!` にエスケープされる問題 → `== ... | not` パターンに変更
- **パターン3**: `pr-watch`/`tdd-next` の `GH_CACHE_DIR` は gh CLI が認識しない環境変数 → `XDG_CACHE_HOME` に修正

## Test plan

- [x] `GH_CACHE_DIR` が全スキルファイルから除去されていること
- [x] `pr-watch` の GraphQL クエリに `$` 変数が残っていないこと
- [x] `pr-watch` の jq 式に `\!=` が残っていないこと
- [x] Local CI (Biome / Test / Build) 全 PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)