### PR TITLE
refactor: LayoutLoader / VialDeviceSection の .label クラスを共通化

### DIFF
--- a/src/components/LayoutLoader/LayoutLoader.module.css
+++ b/src/components/LayoutLoader/LayoutLoader.module.css
@@ -12,12 +12,6 @@
   min-width: 250px;
 }
 
-.label {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--ctp-text);
-}
-
 .dropzone {
   border: 2px dashed var(--ctp-surface2);
   border-radius: 8px;

--- a/src/components/LayoutLoader/LayoutLoader.tsx
+++ b/src/components/LayoutLoader/LayoutLoader.tsx
@@ -3,6 +3,7 @@ import { DEFAULT_LAYOUT_NAME } from "../../data/default-layout";
 import { getPresets } from "../../data/keybinding-presets";
 import type { KeybindingPreset } from "../../types/keybinding";
 import styles from "./LayoutLoader.module.css";
+import sharedStyles from "./shared.module.css";
 import { VialDeviceSection } from "./VialDeviceSection";
 
 /** カスタム選択肢の value 定数 */
@@ -49,7 +50,7 @@ function FileDropZone({
 
   return (
     <div className={styles.dropzoneGroup}>
-      <span className={styles.label}>{label}</span>
+      <span className={sharedStyles.label}>{label}</span>
       {/* biome-ignore lint/a11y/useSemanticElements: ドロップゾーンは drag&drop 対応のため div が必要 */}
       <div
         role="button"
@@ -159,7 +160,7 @@ export function LayoutLoader({
       />
       {/* select + dropzone を束ねるため、ラベルは group 直下に配置 */}
       <div className={styles.keymapGroup}>
-        <span className={styles.label}>2. キーマップ</span>
+        <span className={sharedStyles.label}>2. キーマップ</span>
         <select
           className={styles.presetSelect}
           value={selectedValue}

--- a/src/components/LayoutLoader/VialDeviceSection.module.css
+++ b/src/components/LayoutLoader/VialDeviceSection.module.css
@@ -1,9 +1,3 @@
-.label {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--ctp-text);
-}
-
 .vialSection {
   display: flex;
   flex-direction: column;

--- a/src/components/LayoutLoader/VialDeviceSection.tsx
+++ b/src/components/LayoutLoader/VialDeviceSection.tsx
@@ -1,4 +1,5 @@
 import { useVialDevice } from "../../hooks/useVialDevice";
+import sharedStyles from "./shared.module.css";
 import styles from "./VialDeviceSection.module.css";
 
 interface VialDeviceSectionProps {
@@ -17,7 +18,7 @@ export function VialDeviceSection({
 
   return (
     <div className={styles.vialSection}>
-      <span className={styles.label}>Vial デバイス</span>
+      <span className={sharedStyles.label}>Vial デバイス</span>
       {status === "disconnected" && (
         <button
           type="button"

--- a/src/components/LayoutLoader/shared.module.css
+++ b/src/components/LayoutLoader/shared.module.css
@@ -1,0 +1,5 @@
+.label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ctp-text);
+}


### PR DESCRIPTION
## Summary
- `LayoutLoader.module.css` と `VialDeviceSection.module.css` に重複していた `.label` クラスを `shared.module.css` に一元化
- 両コンポーネント (TSX) で `sharedStyles.label` を参照するよう変更

Closes #200

## Test plan
- [x] 既存テスト 20 件 PASS（LayoutLoader, VialDeviceSection）
- [x] local-ci 全チェック PASS（Biome, Test 748件, Build）
- [ ] 見た目が変わらないことを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)