### PR TITLE
refactor: テストファイルの defaultCustomKeymap ハードコード重複を解消

### DIFF
--- a/src/components/KeymapEditor/KeymapEditor.test.tsx
+++ b/src/components/KeymapEditor/KeymapEditor.test.tsx
@@ -9,7 +9,7 @@ vi.mock("../../utils/storage", async (importOriginal) => ({
 }));
 
 import { KeybindingProvider } from "../../context/KeybindingContext";
-import { QWERTY_KEYS } from "../../data/keymap";
+import { defaultCustomKeymap, QWERTY_KEYS } from "../../data/keymap";
 import type { KeybindingConfig } from "../../types/keybinding";
 import { createDefaultConfig } from "../../utils/keybinding-defaults";
 import { KeymapEditor } from "./KeymapEditor";
@@ -45,40 +45,6 @@ const DUPLICATE_KEYMAP: Record<string, string> = {
   "/": "-",
 };
 
-/** テスト用の defaultCustomKeymap 相当のキーマップ */
-const DEFAULT_KEYMAP: Record<string, string> = {
-  q: "q",
-  w: "l",
-  e: "h",
-  r: "c",
-  t: "f",
-  y: "p",
-  u: "b",
-  i: "u",
-  o: ",",
-  p: ".",
-  a: "a",
-  s: "n",
-  d: "r",
-  f: "s",
-  g: "w",
-  h: "k",
-  j: "t",
-  k: "e",
-  l: "o",
-  ";": "i",
-  z: "-",
-  x: "z",
-  c: "y",
-  v: "m",
-  b: "v",
-  n: "g",
-  m: "d",
-  ",": "j",
-  ".": "x",
-  "/": ";",
-};
-
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -109,7 +75,7 @@ describe("KeymapEditor", () => {
 
   describe("customKeymap の値表示", () => {
     test("customKeymap の出力文字が正しく表示される", () => {
-      renderWithContext(DEFAULT_KEYMAP);
+      renderWithContext(defaultCustomKeymap);
 
       const cellQ = screen.getByTestId("output-cell-q");
       expect(cellQ).toHaveTextContent("q");
@@ -263,7 +229,7 @@ describe("KeymapEditor", () => {
     });
 
     test("重複がないキーには data-error 属性が付かない", () => {
-      renderWithContext(DEFAULT_KEYMAP);
+      renderWithContext(defaultCustomKeymap);
 
       for (const key of QWERTY_KEYS) {
         expect(screen.getByTestId(`output-cell-${key}`)).not.toHaveAttribute(

--- a/src/utils/keymap-validator.test.ts
+++ b/src/utils/keymap-validator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { QWERTY_KEYS } from "../data/keymap";
+import { defaultCustomKeymap, QWERTY_KEYS } from "../data/keymap";
 import type { KeymapValidationError } from "./keymap-validator";
 import { validateKeymap } from "./keymap-validator";
 
@@ -18,40 +18,7 @@ describe("validateKeymap", () => {
     });
 
     it("30キー全てが有効なキーマップでは空配列を返す", () => {
-      const keymap: Record<string, string> = {
-        q: "q",
-        w: "l",
-        e: "h",
-        r: "c",
-        t: "f",
-        y: "p",
-        u: "b",
-        i: "u",
-        o: ",",
-        p: ".",
-        a: "a",
-        s: "n",
-        d: "r",
-        f: "s",
-        g: "w",
-        h: "k",
-        j: "t",
-        k: "e",
-        l: "o",
-        ";": "i",
-        z: "-",
-        x: "z",
-        c: "y",
-        v: "m",
-        b: "v",
-        n: "g",
-        m: "d",
-        ",": "j",
-        ".": "x",
-        "/": ";",
-      };
-
-      const result = validateKeymap(keymap);
+      const result = validateKeymap(defaultCustomKeymap);
 
       expect(result).toEqual([]);
     });


### PR DESCRIPTION
## Summary
- `keymap-validator.test.ts` の30キーハードコードキーマップを `defaultCustomKeymap` インポートに置換
- `KeymapEditor.test.tsx` の `DEFAULT_KEYMAP` 定数を `defaultCustomKeymap` インポートに置換
- 2ファイルで計72行のハードコード重複を削除し、Single Source of Truth に統一

## Test plan
- [x] 全748テスト通過
- [x] Biome lint チェック通過
- [x] 型チェック・ビルド通過

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)