### PR TITLE
test: KeymapEditor の明示渡しとデフォルトフォールバックの検証を分離

### DIFF
--- a/src/components/KeymapEditor/KeymapEditor.test.tsx
+++ b/src/components/KeymapEditor/KeymapEditor.test.tsx
@@ -75,16 +75,16 @@ describe("KeymapEditor", () => {
 
   describe("customKeymap の値表示", () => {
     test("customKeymap の出力文字が正しく表示される", () => {
-      renderWithContext(defaultCustomKeymap);
+      renderWithContext(IDENTITY_KEYMAP);
 
       const cellQ = screen.getByTestId("output-cell-q");
       expect(cellQ).toHaveTextContent("q");
 
       const cellW = screen.getByTestId("output-cell-w");
-      expect(cellW).toHaveTextContent("l");
+      expect(cellW).toHaveTextContent("w");
 
       const cellJ = screen.getByTestId("output-cell-j");
-      expect(cellJ).toHaveTextContent("t");
+      expect(cellJ).toHaveTextContent("j");
     });
 
     test("customKeymap 未設定時は defaultCustomKeymap の値が表示される", () => {


### PR DESCRIPTION
## Summary
- L77「customKeymap の出力文字が正しく表示される」で `defaultCustomKeymap` → `IDENTITY_KEYMAP` に変更
- アサーション値を `w→w, j→j`（IDENTITY_KEYMAP の値）に更新し、L90 のフォールバックテスト（`w→l, j→t`）と明確に区別

## Test plan
- [x] KeymapEditor テスト 16 件全て PASS
- [x] 全テスト 773 件 PASS
- [x] Biome check PASS
- [x] Build PASS

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)