### PR TITLE
fix: session-done.sh の checkout main を fetch に置換 (#224)

### DIFF
--- a/.claude/scripts/session-done.sh
+++ b/.claude/scripts/session-done.sh
@@ -55,9 +55,8 @@ if [[ -z "$next_issues" || "$next_issues" == "null" ]]; then
   exit 0
 fi
 
-# main を最新化してから次セットをディスパッチ
-git -C "$PROJECT_DIR" checkout main 2>&1 || echo "checkout main failed, continuing with current HEAD" >&2
-git -C "$PROJECT_DIR" pull --ff-only origin main 2>&1 || echo "pull --ff-only failed, continuing with local main" >&2
+# main を最新化（HEAD を変更しないよう fetch のみ）
+git -C "$PROJECT_DIR" fetch origin main 2>&1 || echo "fetch origin main failed, continuing with local state" >&2
 
 # 次セットを dispatched に更新
 jq '


### PR DESCRIPTION
## Summary
- `session-done.sh` の `git checkout main && git pull --ff-only` を `git fetch origin main` に置換
- メインセッションの HEAD を変更せず、`origin/main` のリモート追跡ブランチのみ更新するように修正
- `dispatch-parallel` スキルと同じ `fetch + origin/main` パターンに統一

Closes #224

## Test plan
- [ ] メインセッションが別ブランチで作業中に `session-done.sh` が発火しても HEAD が変わらないこと
- [ ] 次セットの worktree が最新の `origin/main` ベースで作成されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)