### PR TITLE
refactor: マジック文字列 "misc" を定数化

### DIFF
--- a/src/types/vim.ts
+++ b/src/types/vim.ts
@@ -24,6 +24,9 @@ export const VIM_COMMAND_CATEGORIES = [
   "misc",
 ] as const satisfies VimCommandCategory[];
 
+/** nvim マッピング新規エントリのデフォルトカテゴリ */
+export const DEFAULT_NVIM_MAP_CATEGORY: VimCommandCategory = "misc";
+
 // ── Neovim map 連携 ──
 
 export type NvimMapMode = "n" | "x" | "o" | "v" | "s" | "!" | "";

--- a/src/utils/merge-vim-commands.test.ts
+++ b/src/utils/merge-vim-commands.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { VimMode } from "../types/keybinding";
 import type { NvimMapping, VimCommand } from "../types/vim";
+import { DEFAULT_NVIM_MAP_CATEGORY } from "../types/vim";
 import { mergeWithNvimMaps } from "./merge-vim-commands";
 
 const baseCommands: VimCommand[] = [
@@ -49,7 +50,7 @@ describe("mergeWithNvimMaps", () => {
     const gd = result.find((c) => c.key === "gd");
     expect(gd).toBeDefined();
     expect(gd?.description).toBe("Go to definition");
-    expect(gd?.category).toBe("misc");
+    expect(gd?.category).toBe(DEFAULT_NVIM_MAP_CATEGORY);
   });
 
   it("description が空の nvim マップはスキップされる", () => {

--- a/src/utils/merge-vim-commands.ts
+++ b/src/utils/merge-vim-commands.ts
@@ -1,6 +1,6 @@
 import type { VimMode } from "../types/keybinding";
 import type { MergedVimCommand, NvimMapping, VimCommand } from "../types/vim";
-import { expandNvimMapMode } from "../types/vim";
+import { DEFAULT_NVIM_MAP_CATEGORY, expandNvimMapMode } from "../types/vim";
 
 /**
  * ハードコードの Vim コマンドと nvim の実マッピングをマージする
@@ -49,7 +49,7 @@ export function mergeWithNvimMaps(
         key,
         name: key,
         description,
-        category: "misc",
+        category: DEFAULT_NVIM_MAP_CATEGORY,
         source: nvMap.source,
         modes: expandedModes,
       });


### PR DESCRIPTION
## Summary
- `src/utils/merge-vim-commands.ts` L52 のマジック文字列 `"misc"` を `DEFAULT_NVIM_MAP_CATEGORY` 定数に置換
- `src/types/vim.ts` に `DEFAULT_NVIM_MAP_CATEGORY: VimCommandCategory = "misc"` を追加
- テストも定数参照に更新

Closes #126

## Test plan
- [x] 既存テスト 773/773 パス
- [x] Biome check パス
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)