### PR TITLE
feat: git push 前の自動 lint・test・build チェックを追加

### DIFF
--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# -e は wait の exit code 取得前にスクリプトが中断するため省略
+set -uo pipefail
+
+COMMAND=$(cat | jq -r '.tool_input.command // empty')
+[[ "$COMMAND" == *"git push"* ]] || exit 0
+
+UPSTREAM=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo "origin/main")
+CHANGED_FILES=$(git diff --name-only "${UPSTREAM}...HEAD" 2>/dev/null || true)
+
+NON_CLAUDE_FILES=$(echo "$CHANGED_FILES" | grep -v '^\.claude/' | grep -v '^$' || true)
+if [[ -z "$NON_CLAUDE_FILES" ]]; then
+  echo "変更は .claude/ 配下のみ — pre-push チェックをスキップ"
+  exit 0
+fi
+
+PNPM=$( [ "$(git rev-parse --git-common-dir 2>/dev/null)" != ".git" ] && echo /etc/profiles/per-user/shiroino/bin/pnpm || echo pnpm )
+
+TMPDIR_HOOK=$(mktemp -d "${TMPDIR:-/tmp}/pre-push-check.XXXXXX")
+trap 'rm -rf "$TMPDIR_HOOK"' EXIT
+
+$PNPM lint  > "$TMPDIR_HOOK/lint.log"  2>&1 &  LINT_PID=$!
+$PNPM test  > "$TMPDIR_HOOK/test.log"  2>&1 &  TEST_PID=$!
+$PNPM build > "$TMPDIR_HOOK/build.log" 2>&1 &  BUILD_PID=$!
+
+wait $LINT_PID;  LINT_EXIT=$?
+wait $TEST_PID;  TEST_EXIT=$?
+wait $BUILD_PID; BUILD_EXIT=$?
+
+lint_status()  { [ $LINT_EXIT  -eq 0 ] && echo "PASS ✓" || echo "FAIL ✗"; }
+test_status()  { [ $TEST_EXIT  -eq 0 ] && echo "PASS ✓" || echo "FAIL ✗"; }
+build_status() { [ $BUILD_EXIT -eq 0 ] && echo "PASS ✓" || echo "FAIL ✗"; }
+
+echo ""
+echo "=== Pre-push チェック結果 ==="
+echo "lint:  $(lint_status)"
+echo "test:  $(test_status)"
+echo "build: $(build_status)"
+
+if [ $LINT_EXIT -ne 0 ] || [ $TEST_EXIT -ne 0 ] || [ $BUILD_EXIT -ne 0 ]; then
+  echo ""
+  [ $LINT_EXIT  -ne 0 ] && { echo "--- lint エラー ---"; cat "$TMPDIR_HOOK/lint.log"; }
+  [ $TEST_EXIT  -ne 0 ] && { echo "--- test エラー ---"; cat "$TMPDIR_HOOK/test.log"; }
+  [ $BUILD_EXIT -ne 0 ] && { echo "--- build エラー ---"; cat "$TMPDIR_HOOK/build.log"; }
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,18 @@
     ]
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/pre-push-check.sh",
+            "timeout": 300
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write",


### PR DESCRIPTION
## Summary
- Claude Code の PreToolUse hook で `git push` を検知し、lint・test・build を並列実行する仕組みを追加
- いずれかのチェックが失敗した場合は `exit 2` で push をブロック
- `.claude/` 配下のみの変更時はチェックをスキップ
- Worktree 環境での pnpm パス解決に対応

Closes #218

## Test plan
- [ ] Claude Code 経由で `git push` 実行時に lint・test・build が自動で走ることを確認
- [ ] チェック失敗時に push がブロックされることを確認
- [ ] `.claude/` のみの変更時にスキップされることを確認
- [ ] Worktree 環境で動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)