### PR TITLE
refactor: PracticePrompt テストの data-testid 安定化

### DIFF
--- a/src/components/PracticeMode/PracticePrompt.test.tsx
+++ b/src/components/PracticeMode/PracticePrompt.test.tsx
@@ -178,56 +178,26 @@ describe("PracticePrompt", () => {
     });
   });
 
-  describe("lastResult による className 変化", () => {
-    test("lastResult=null のとき correct/incorrect クラスが付かない", () => {
-      const { container } = render(
-        <PracticePrompt {...defaultProps} lastResult={null} />,
-      );
+  describe("lastResult による data-result 属性", () => {
+    test("lastResult=null のとき data-result 属性がない", () => {
+      render(<PracticePrompt {...defaultProps} lastResult={null} />);
 
-      const panel = container.firstChild as HTMLElement;
-      expect(panel).not.toBeNull();
-      expect(panel.className).not.toMatch(/_correct_/);
-      expect(panel.className).not.toMatch(/_incorrect_/);
+      const panel = screen.getByTestId("practice-prompt");
+      expect(panel).not.toHaveAttribute("data-result");
     });
 
-    test("lastResult='correct' のとき correct クラスが付く", () => {
-      const { container } = render(
-        <PracticePrompt {...defaultProps} lastResult="correct" />,
-      );
+    test("lastResult='correct' のとき data-result='correct'", () => {
+      render(<PracticePrompt {...defaultProps} lastResult="correct" />);
 
-      const panel = container.firstChild as HTMLElement;
-      expect(panel).not.toBeNull();
-      expect(panel.className).toMatch(/_correct_/);
+      const panel = screen.getByTestId("practice-prompt");
+      expect(panel).toHaveAttribute("data-result", "correct");
     });
 
-    test("lastResult='incorrect' のとき incorrect クラスが付く", () => {
-      const { container } = render(
-        <PracticePrompt {...defaultProps} lastResult="incorrect" />,
-      );
+    test("lastResult='incorrect' のとき data-result='incorrect'", () => {
+      render(<PracticePrompt {...defaultProps} lastResult="incorrect" />);
 
-      const panel = container.firstChild as HTMLElement;
-      expect(panel).not.toBeNull();
-      expect(panel.className).toMatch(/_incorrect_/);
-    });
-
-    test("lastResult='correct' のとき incorrect クラスが付かない", () => {
-      const { container } = render(
-        <PracticePrompt {...defaultProps} lastResult="correct" />,
-      );
-
-      const panel = container.firstChild as HTMLElement;
-      expect(panel).not.toBeNull();
-      expect(panel.className).not.toMatch(/_incorrect_/);
-    });
-
-    test("lastResult='incorrect' のとき correct クラスが付かない", () => {
-      const { container } = render(
-        <PracticePrompt {...defaultProps} lastResult="incorrect" />,
-      );
-
-      const panel = container.firstChild as HTMLElement;
-      expect(panel).not.toBeNull();
-      expect(panel.className).not.toMatch(/_correct_/);
+      const panel = screen.getByTestId("practice-prompt");
+      expect(panel).toHaveAttribute("data-result", "incorrect");
     });
   });
 
@@ -295,9 +265,9 @@ describe("PracticePrompt", () => {
 
   describe("スナップショット", () => {
     test("コマンドあり・lastResult=null のデフォルト状態", () => {
-      const { container } = render(<PracticePrompt {...defaultProps} />);
+      render(<PracticePrompt {...defaultProps} />);
 
-      expect(container.firstChild).toMatchSnapshot();
+      expect(screen.getByTestId("practice-prompt")).toMatchSnapshot();
     });
   });
 });

--- a/src/components/PracticeMode/PracticePrompt.tsx
+++ b/src/components/PracticeMode/PracticePrompt.tsx
@@ -22,7 +22,7 @@ export function PracticePrompt({
 }: PracticePromptProps) {
   if (!started) {
     return (
-      <div className={styles.panel}>
+      <div className={styles.panel} data-testid="practice-prompt">
         <button type="button" className={styles.startButton} onClick={onStart}>
           練習を開始
         </button>
@@ -32,7 +32,7 @@ export function PracticePrompt({
 
   if (!command) {
     return (
-      <div className={styles.panel}>
+      <div className={styles.panel} data-testid="practice-prompt">
         <p className={styles.message}>
           選択したカテゴリに出題可能なコマンドがありません
         </p>
@@ -52,6 +52,8 @@ export function PracticePrompt({
         lastResult === "correct" && styles.correct,
         lastResult === "incorrect" && styles.incorrect,
       )}
+      data-testid="practice-prompt"
+      data-result={lastResult}
     >
       <div className={styles.prompt}>
         <span
@@ -64,7 +66,11 @@ export function PracticePrompt({
         <span className={styles.description}>{command.description}</span>
       </div>
       <div className={styles.hintRow}>
-        {showHint && <span className={styles.hint}>{inputSpec.hint}</span>}
+        {showHint && (
+          <span className={styles.hint} data-testid="hint">
+            {inputSpec.hint}
+          </span>
+        )}
         <span className={styles.instruction}>を押してください</span>
       </div>
       <div className={styles.score}>

--- a/src/components/PracticeMode/__snapshots__/PracticePrompt.test.tsx.snap
+++ b/src/components/PracticeMode/__snapshots__/PracticePrompt.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`PracticePrompt > スナップショット > コマンドあり・lastResult=null のデフォルト状態 1`] = `
 <div
   class="_panel_c028ee"
+  data-testid="practice-prompt"
 >
   <div
     class="_prompt_c028ee"


### PR DESCRIPTION
## Summary
- `PracticePrompt.tsx` のルート div に `data-testid="practice-prompt"`、ヒント span に `data-testid="hint"` を追加
- `lastResult` の状態を `data-result` 属性で表現し、CSS Modules クラス名依存を排除
- テストの `container.firstChild as HTMLElement` を全て `screen.getByTestId()` に置換

Closes #217

## Test plan
- [x] PracticePrompt テスト全 23 件 PASSED
- [x] 全体テスト 771 件 PASSED
- [x] Biome lint PASSED
- [x] TypeScript + Vite ビルド PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)