### PR TITLE
feat: draft ラベル削除時の Project 未登録検出 hook を追加

### DIFF
--- a/.claude/scripts/project-status-check.sh
+++ b/.claude/scripts/project-status-check.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# project-status-check.sh — PostToolUse(Bash) hook
+# gh issue edit --remove-label draft 実行後に Project 登録漏れを検出する
+set -euo pipefail
+
+COMMAND=$(cat | jq -r '.tool_input.command // empty')
+
+# draft ラベル削除コマンドでなければ早期 return
+if ! [[ "$COMMAND" =~ gh[[:space:]]+issue[[:space:]]+edit[[:space:]]+([0-9]+).*--remove-label.*draft ]]; then
+  exit 0
+fi
+
+ISSUE_NUMBER="${BASH_REMATCH[1]}"
+
+# Issue の URL を取得
+ISSUE_URL=$(gh issue view "$ISSUE_NUMBER" --json url -q '.url' 2>/dev/null || true)
+if [[ -z "$ISSUE_URL" ]]; then
+  echo "WARNING: Issue #${ISSUE_NUMBER} の URL を取得できませんでした" >&2
+  exit 0
+fi
+
+# Project に登録済みか確認（Issue URL で絞り込む）
+REGISTERED=$(gh project item-list 6 --owner shiroinock --limit 100 --format json 2>/dev/null \
+  | jq --arg url "$ISSUE_URL" '[.items[] | select(.content.url == $url)] | length')
+
+if [[ "$REGISTERED" -eq 0 ]]; then
+  echo ""
+  echo "WARNING: Issue #${ISSUE_NUMBER} が Project に未登録です。"
+  echo "以下のコマンドで登録してください:"
+  echo ""
+  echo "  gh project item-add 6 --owner shiroinock --url ${ISSUE_URL}"
+  echo ""
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,6 +30,16 @@
             "timeout": 60
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/scripts/project-status-check.sh",
+            "timeout": 30
+          }
+        ]
       }
     ]
   }

--- a/.claude/skills/issue-enrichment/SKILL.md
+++ b/.claude/skills/issue-enrichment/SKILL.md
@@ -157,16 +157,17 @@ gh project item-edit --id "{item_id}" \
 # Issue 本文を更新
 gh issue edit {番号} --body "{作成した本文}"
 
-# draft ラベルを剥がす
+# draft ラベルを剥がし、直後に必ず Project に追加する（セットで実行すること）
 gh issue edit {番号} --remove-label "draft"
-
-# Issue を Project に追加
 gh project item-add 6 --owner shiroinock --url {IssueのURL}
 ```
 
 - `draft` ラベルは対象 Issue（親含む）全てから剥がす
+- **`gh project item-add` は必須**。`draft` ラベル削除と Project 登録は必ずセットで実行する
 - 親 Issue は Project に追加し、Status を **In Progress** にする（epic として進行中）
 - 子 Issue は Project に追加し、Status を **Todo** にする
+
+> **補足**: PostToolUse(Bash) hook が `--remove-label draft` を検出し、Project 未登録の場合は警告と登録コマンドを表示する。スキップした場合も hook が検出するが、**最初から省略しないこと**。
 
 ### 6. ユーザーへの報告
 


### PR DESCRIPTION
## Summary
- PostToolUse(Bash) hook で `gh issue edit --remove-label draft` を検出し、対象 Issue が Project に未登録の場合に警告と登録コマンドを表示する
- issue-enrichment スキルのステップ 5 で `gh project item-add` が必須であることを明記・強化
- 既存の漏れ Issue 5件（#75, #107, #108, #126, #214）は既に Project 登録済みであることを確認

Closes #219

## Test plan
- [ ] `gh issue edit {番号} --remove-label "draft"` 実行後、Project 未登録の Issue に対して警告が表示されることを確認
- [ ] Project 登録済みの Issue に対しては警告が表示されないことを確認
- [ ] 無関係な Bash コマンド実行時に hook が早期 return し、パフォーマンスに影響しないことを確認
- [ ] 既存の Write hook（dispatch-on-write.sh）が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)