### PR TITLE
refactor: KeybindingSource リテラルを個別定数に置換

### DIFF
--- a/src/components/BindingEditor/BindingEditor.test.tsx
+++ b/src/components/BindingEditor/BindingEditor.test.tsx
@@ -2,7 +2,11 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 import * as KeybindingContextModule from "../../context/KeybindingContext";
 import type { Keybinding, KeybindingConfig } from "../../types/keybinding";
-import { emptyBindings } from "../../types/keybinding";
+import {
+  emptyBindings,
+  KEYBINDING_SOURCE_DEFAULT,
+  KEYBINDING_SOURCE_LAYOUT_DERIVED,
+} from "../../types/keybinding";
 import { BindingEditor } from "./BindingEditor";
 
 const mockDispatch = vi.fn();
@@ -12,7 +16,7 @@ const makeBinding = (overrides: Partial<Keybinding> = {}): Keybinding => ({
   name: "↓",
   description: "下に移動",
   category: "motion",
-  source: "default",
+  source: KEYBINDING_SOURCE_DEFAULT,
   noremap: false,
   ...overrides,
 });
@@ -43,7 +47,7 @@ describe("BindingEditor", () => {
             lhs: "j",
             name: "↓",
             category: "motion",
-            source: "default",
+            source: KEYBINDING_SOURCE_DEFAULT,
           }),
         ]),
       );
@@ -243,14 +247,14 @@ describe("BindingEditor", () => {
             name: "↓",
             description: "下に移動",
             category: "motion",
-            source: "default",
+            source: KEYBINDING_SOURCE_DEFAULT,
           }),
           makeBinding({
             lhs: "k",
             name: "↑",
             description: "上に移動",
             category: "motion",
-            source: "layout-derived",
+            source: KEYBINDING_SOURCE_LAYOUT_DERIVED,
           }),
         ]),
       );

--- a/src/components/BindingEditor/BindingEditor.tsx
+++ b/src/components/BindingEditor/BindingEditor.tsx
@@ -6,24 +6,30 @@ import {
   sourceColors,
 } from "../../data/vim-commands";
 import type { KeybindingSource, VimMode } from "../../types/keybinding";
+import {
+  KEYBINDING_SOURCE_DEFAULT,
+  KEYBINDING_SOURCE_LAYOUT_DERIVED,
+  KEYBINDING_SOURCE_NVIM_IMPORT,
+  KEYBINDING_SOURCE_USER_EDIT,
+} from "../../types/keybinding";
 import { cx } from "../../utils/cx";
 import { KeyCapture } from "../KeyCapture/KeyCapture";
 import { ModeSelector } from "../ModeSelector/ModeSelector";
 import styles from "./BindingEditor.module.css";
 
-const SOURCE_DISPLAY_KEYS: Record<KeybindingSource, string> = {
-  default: "hardcoded",
-  "layout-derived": "nvim-default",
-  "nvim-import": "plugin",
-  "user-edit": "user",
-};
+const SOURCE_DISPLAY_KEYS = {
+  [KEYBINDING_SOURCE_DEFAULT]: "hardcoded",
+  [KEYBINDING_SOURCE_LAYOUT_DERIVED]: "nvim-default",
+  [KEYBINDING_SOURCE_NVIM_IMPORT]: "plugin",
+  [KEYBINDING_SOURCE_USER_EDIT]: "user",
+} satisfies Record<KeybindingSource, string>;
 
-const SOURCE_LABELS: Record<KeybindingSource, string> = {
-  default: "デフォルト",
-  "layout-derived": "レイアウト",
-  "nvim-import": "nvim",
-  "user-edit": "ユーザー",
-};
+const SOURCE_LABELS = {
+  [KEYBINDING_SOURCE_DEFAULT]: "デフォルト",
+  [KEYBINDING_SOURCE_LAYOUT_DERIVED]: "レイアウト",
+  [KEYBINDING_SOURCE_NVIM_IMPORT]: "nvim",
+  [KEYBINDING_SOURCE_USER_EDIT]: "ユーザー",
+} satisfies Record<KeybindingSource, string>;
 
 export function BindingEditor() {
   const { config, dispatch } = useKeybindingContext();

--- a/src/components/ExportPanel/ExportPanel.test.tsx
+++ b/src/components/ExportPanel/ExportPanel.test.tsx
@@ -17,6 +17,7 @@ vi.mock("../../utils/keybinding-exporters", () => ({
 
 import { useKeybindingContext } from "../../context/KeybindingContext";
 import type { Keybinding, VimMode } from "../../types/keybinding";
+import { KEYBINDING_SOURCE_DEFAULT } from "../../types/keybinding";
 import {
   keybindingToJSON,
   keybindingToLangmap,
@@ -49,7 +50,7 @@ function buildConfigWithBindings(): KeybindingConfig {
       name: "Move down",
       description: "Move cursor down",
       category: "motion",
-      source: "default",
+      source: KEYBINDING_SOURCE_DEFAULT,
       noremap: true,
     },
   ];

--- a/src/context/KeybindingContext.test.tsx
+++ b/src/context/KeybindingContext.test.tsx
@@ -9,6 +9,10 @@ vi.mock("../utils/storage", async (importOriginal) => ({
 }));
 
 import type { KeybindingConfig } from "../types/keybinding";
+import {
+  KEYBINDING_SOURCE_DEFAULT,
+  KEYBINDING_SOURCE_USER_EDIT,
+} from "../types/keybinding";
 import { loadKeybindingConfig } from "../utils/storage";
 import { KeybindingProvider, useKeybindingContext } from "./KeybindingContext";
 
@@ -24,7 +28,7 @@ const savedConfig: KeybindingConfig = {
         name: "下に移動",
         description: "カーソルを下に移動",
         category: "motion",
-        source: "user-edit",
+        source: KEYBINDING_SOURCE_USER_EDIT,
         noremap: true,
       },
     ],
@@ -50,7 +54,7 @@ const initialConfig: KeybindingConfig = {
         name: "上に移動",
         description: "カーソルを上に移動",
         category: "motion",
-        source: "default",
+        source: KEYBINDING_SOURCE_DEFAULT,
         noremap: true,
       },
     ],

--- a/src/hooks/useKeybindingConfig.test.ts
+++ b/src/hooks/useKeybindingConfig.test.ts
@@ -6,6 +6,7 @@ vi.mock("../utils/storage", async (importOriginal) => ({
   saveKeybindingConfig: vi.fn(),
 }));
 
+import { KEYBINDING_SOURCE_USER_EDIT } from "../types/keybinding";
 import type { NvimMapping } from "../types/vim";
 import { saveKeybindingConfig } from "../utils/storage";
 import { useKeybindingConfig } from "./useKeybindingConfig";
@@ -38,7 +39,7 @@ describe("useKeybindingConfig — localStorage 永続化", () => {
             name: "テストバインディング",
             description: "テスト用",
             category: "motion",
-            source: "user-edit",
+            source: KEYBINDING_SOURCE_USER_EDIT,
             noremap: true,
           },
         });
@@ -76,7 +77,7 @@ describe("useKeybindingConfig — localStorage 永続化", () => {
             name: "テストバインディング",
             description: "テスト用",
             category: "motion",
-            source: "user-edit",
+            source: KEYBINDING_SOURCE_USER_EDIT,
             noremap: true,
           },
         });
@@ -102,7 +103,7 @@ describe("useKeybindingConfig — localStorage 永続化", () => {
             name: "1回目のバインディング",
             description: "1回目",
             category: "motion",
-            source: "user-edit",
+            source: KEYBINDING_SOURCE_USER_EDIT,
             noremap: true,
           },
         });
@@ -117,7 +118,7 @@ describe("useKeybindingConfig — localStorage 永続化", () => {
             name: "2回目のバインディング",
             description: "2回目",
             category: "motion",
-            source: "user-edit",
+            source: KEYBINDING_SOURCE_USER_EDIT,
             noremap: true,
           },
         });

--- a/src/hooks/useKeybindingConfig.ts
+++ b/src/hooks/useKeybindingConfig.ts
@@ -6,6 +6,7 @@ import type {
   KeybindingConfig,
   VimMode,
 } from "../types/keybinding";
+import { KEYBINDING_SOURCE_USER_EDIT } from "../types/keybinding";
 import type { NvimMapping } from "../types/vim";
 import { convertNvimMapsToKeybindings } from "../utils/convert-nvim-to-keybinding";
 import { createDefaultConfig } from "../utils/keybinding-defaults";
@@ -46,7 +47,7 @@ function keybindingReducer(
       modeBindings[action.index] = {
         ...modeBindings[action.index],
         ...action.binding,
-        source: "user-edit",
+        source: KEYBINDING_SOURCE_USER_EDIT,
       };
       return {
         ...state,

--- a/src/types/keybinding.test.ts
+++ b/src/types/keybinding.test.ts
@@ -4,6 +4,10 @@ import {
   APP_MODE_LABELS,
   APP_MODES,
   HIGHLIGHT_MODES,
+  KEYBINDING_SOURCE_DEFAULT,
+  KEYBINDING_SOURCE_LAYOUT_DERIVED,
+  KEYBINDING_SOURCE_NVIM_IMPORT,
+  KEYBINDING_SOURCE_USER_EDIT,
   KEYBINDING_SOURCES,
   KEYBOARD_HIDDEN_MODES,
   KEYBOARD_PLAIN_MODES,
@@ -60,6 +64,31 @@ describe("KEYBINDING_SOURCES", () => {
   test("重複がない", () => {
     const unique = new Set<string>(KEYBINDING_SOURCES);
     expect(unique.size).toBe(KEYBINDING_SOURCES.length);
+  });
+});
+
+describe("KeybindingSource 個別定数", () => {
+  test('KEYBINDING_SOURCE_DEFAULT が "default" と等しい', () => {
+    expect(KEYBINDING_SOURCE_DEFAULT).toBe("default");
+  });
+
+  test('KEYBINDING_SOURCE_LAYOUT_DERIVED が "layout-derived" と等しい', () => {
+    expect(KEYBINDING_SOURCE_LAYOUT_DERIVED).toBe("layout-derived");
+  });
+
+  test('KEYBINDING_SOURCE_NVIM_IMPORT が "nvim-import" と等しい', () => {
+    expect(KEYBINDING_SOURCE_NVIM_IMPORT).toBe("nvim-import");
+  });
+
+  test('KEYBINDING_SOURCE_USER_EDIT が "user-edit" と等しい', () => {
+    expect(KEYBINDING_SOURCE_USER_EDIT).toBe("user-edit");
+  });
+
+  test("全定数が KEYBINDING_SOURCES 配列に含まれる", () => {
+    expect(KEYBINDING_SOURCES).toContain(KEYBINDING_SOURCE_DEFAULT);
+    expect(KEYBINDING_SOURCES).toContain(KEYBINDING_SOURCE_LAYOUT_DERIVED);
+    expect(KEYBINDING_SOURCES).toContain(KEYBINDING_SOURCE_NVIM_IMPORT);
+    expect(KEYBINDING_SOURCES).toContain(KEYBINDING_SOURCE_USER_EDIT);
   });
 });
 

--- a/src/types/keybinding.ts
+++ b/src/types/keybinding.ts
@@ -92,6 +92,15 @@ export const KEYBINDING_SOURCES = [
   "user-edit",
 ] as const satisfies KeybindingSource[];
 
+export const KEYBINDING_SOURCE_DEFAULT =
+  "default" as const satisfies KeybindingSource;
+export const KEYBINDING_SOURCE_LAYOUT_DERIVED =
+  "layout-derived" as const satisfies KeybindingSource;
+export const KEYBINDING_SOURCE_NVIM_IMPORT =
+  "nvim-import" as const satisfies KeybindingSource;
+export const KEYBINDING_SOURCE_USER_EDIT =
+  "user-edit" as const satisfies KeybindingSource;
+
 /** 個別のキーバインディング */
 export interface Keybinding {
   /** キーシーケンス ("j", "dd", "<C-f>", "<leader>ff") */

--- a/src/utils/convert-nvim-to-keybinding.test.ts
+++ b/src/utils/convert-nvim-to-keybinding.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { VimMode } from "../types/keybinding";
+import { KEYBINDING_SOURCE_NVIM_IMPORT } from "../types/keybinding";
 import type { NvimMapping, VimCommand } from "../types/vim";
 import { convertNvimMapsToKeybindings } from "./convert-nvim-to-keybinding";
 
@@ -119,14 +120,14 @@ describe("convertNvimMapsToKeybindings", () => {
       const maps = [makeNvimMap({ lhs: "j", mode: "n" })];
       const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
 
-      expect(result.n[0].source).toBe("nvim-import");
+      expect(result.n[0].source).toBe(KEYBINDING_SOURCE_NVIM_IMPORT);
     });
 
     it("VimCommand にマッチしないマップの source が 'nvim-import' になる", () => {
       const maps = [makeNvimMap({ lhs: "gd", mode: "n" })];
       const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
 
-      expect(result.n[0].source).toBe("nvim-import");
+      expect(result.n[0].source).toBe(KEYBINDING_SOURCE_NVIM_IMPORT);
     });
 
     it("複数マップの全バインディングの source が 'nvim-import' になる", () => {
@@ -137,7 +138,9 @@ describe("convertNvimMapsToKeybindings", () => {
       ];
       const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
 
-      expect(result.n.every((b) => b.source === "nvim-import")).toBe(true);
+      expect(
+        result.n.every((b) => b.source === KEYBINDING_SOURCE_NVIM_IMPORT),
+      ).toBe(true);
     });
   });
 

--- a/src/utils/convert-nvim-to-keybinding.ts
+++ b/src/utils/convert-nvim-to-keybinding.ts
@@ -1,5 +1,8 @@
 import type { Keybinding, VimMode } from "../types/keybinding";
-import { emptyBindings } from "../types/keybinding";
+import {
+  emptyBindings,
+  KEYBINDING_SOURCE_NVIM_IMPORT,
+} from "../types/keybinding";
 import type { NvimMapping, VimCommand } from "../types/vim";
 import { expandNvimMapMode } from "../types/vim";
 
@@ -22,7 +25,7 @@ export function convertNvimMapsToKeybindings(
           name: matched.name,
           description: matched.description,
           category: matched.category,
-          source: "nvim-import",
+          source: KEYBINDING_SOURCE_NVIM_IMPORT,
           noremap: map.noremap,
         }
       : {
@@ -31,7 +34,7 @@ export function convertNvimMapsToKeybindings(
           name: map.lhs,
           description: map.description,
           category: "misc",
-          source: "nvim-import",
+          source: KEYBINDING_SOURCE_NVIM_IMPORT,
           noremap: map.noremap,
         };
 

--- a/src/utils/keybinding-defaults.test.ts
+++ b/src/utils/keybinding-defaults.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { VimMode } from "../types/keybinding";
+import {
+  KEYBINDING_SOURCE_DEFAULT,
+  KEYBINDING_SOURCE_NVIM_IMPORT,
+} from "../types/keybinding";
 import type { VimCommand } from "../types/vim";
 import { commandsToBindings, createDefaultConfig } from "./keybinding-defaults";
 
@@ -34,7 +38,7 @@ describe("createDefaultConfig", () => {
       expect(kb).toHaveProperty("name");
       expect(kb).toHaveProperty("description");
       expect(kb).toHaveProperty("category");
-      expect(kb.source).toBe("default");
+      expect(kb.source).toBe(KEYBINDING_SOURCE_DEFAULT);
       expect(kb.noremap).toBe(true);
     }
   });
@@ -76,9 +80,13 @@ describe("commandsToBindings", () => {
   });
 
   it("source パラメータが反映される", () => {
-    const result = commandsToBindings(testCommands, "n", "nvim-import");
+    const result = commandsToBindings(
+      testCommands,
+      "n",
+      KEYBINDING_SOURCE_NVIM_IMPORT,
+    );
     for (const kb of result) {
-      expect(kb.source).toBe("nvim-import");
+      expect(kb.source).toBe(KEYBINDING_SOURCE_NVIM_IMPORT);
     }
   });
 });

--- a/src/utils/keybinding-defaults.ts
+++ b/src/utils/keybinding-defaults.ts
@@ -4,7 +4,7 @@ import type {
   KeybindingConfig,
   VimMode,
 } from "../types/keybinding";
-import { emptyBindings } from "../types/keybinding";
+import { emptyBindings, KEYBINDING_SOURCE_DEFAULT } from "../types/keybinding";
 import type { VimCommand } from "../types/vim";
 import { CURRENT_KEYBINDING_VERSION } from "./storage";
 
@@ -13,7 +13,7 @@ import { CURRENT_KEYBINDING_VERSION } from "./storage";
  */
 function commandToKeybinding(
   cmd: VimCommand,
-  source: Keybinding["source"] = "default",
+  source: Keybinding["source"] = KEYBINDING_SOURCE_DEFAULT,
 ): Keybinding {
   return {
     lhs: cmd.key,
@@ -57,7 +57,7 @@ export function createDefaultConfig(name = "QWERTY Default"): KeybindingConfig {
 export function commandsToBindings(
   commands: VimCommand[],
   mode: VimMode,
-  source: Keybinding["source"] = "default",
+  source: Keybinding["source"] = KEYBINDING_SOURCE_DEFAULT,
 ): Keybinding[] {
   void mode; // 将来のモード別フィルタリング用
   return commands.map((cmd) => commandToKeybinding(cmd, source));

--- a/src/utils/keybinding-exporters.test.ts
+++ b/src/utils/keybinding-exporters.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { defaultCustomKeymap } from "../data/keymap";
 import type { Keybinding, KeybindingConfig } from "../types/keybinding";
-import { emptyBindings } from "../types/keybinding";
+import {
+  emptyBindings,
+  KEYBINDING_SOURCE_DEFAULT,
+  KEYBINDING_SOURCE_USER_EDIT,
+} from "../types/keybinding";
 import {
   keybindingToJSON,
   keybindingToLangmap,
@@ -16,7 +20,7 @@ function makeKeybinding(
     name: "テストコマンド",
     description: "テスト用",
     category: "motion",
-    source: "default",
+    source: KEYBINDING_SOURCE_DEFAULT,
     noremap: true,
     ...overrides,
   };
@@ -474,7 +478,7 @@ describe("keybindingToJSON", () => {
               commandId: "ff",
               rhs: ":Telescope find_files<CR>",
               noremap: true,
-              source: "user-edit",
+              source: KEYBINDING_SOURCE_USER_EDIT,
               name: "ファイル検索",
               description: "Telescope でファイルを検索",
               category: "misc",
@@ -491,7 +495,7 @@ describe("keybindingToJSON", () => {
       expect(binding.commandId).toBe("ff");
       expect(binding.rhs).toBe(":Telescope find_files<CR>");
       expect(binding.noremap).toBe(true);
-      expect(binding.source).toBe("user-edit");
+      expect(binding.source).toBe(KEYBINDING_SOURCE_USER_EDIT);
     });
   });
 

--- a/src/utils/keybinding-from-layout.test.ts
+++ b/src/utils/keybinding-from-layout.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { VimMode } from "../types/keybinding";
+import { KEYBINDING_SOURCE_LAYOUT_DERIVED } from "../types/keybinding";
 import { deriveFromLayout } from "./keybinding-from-layout";
 
 describe("deriveFromLayout", () => {
@@ -28,7 +29,7 @@ describe("deriveFromLayout", () => {
 
   it("source が 'layout-derived' である", () => {
     for (const kb of config.bindings.n) {
-      expect(kb.source).toBe("layout-derived");
+      expect(kb.source).toBe(KEYBINDING_SOURCE_LAYOUT_DERIVED);
     }
   });
 

--- a/src/utils/keybinding-from-layout.ts
+++ b/src/utils/keybinding-from-layout.ts
@@ -1,7 +1,10 @@
 import { invertKeymap } from "../data/keymap";
 import { decomposeVimKey, vimCommands } from "../data/vim-commands";
 import type { Keybinding, KeybindingConfig } from "../types/keybinding";
-import { emptyBindings } from "../types/keybinding";
+import {
+  emptyBindings,
+  KEYBINDING_SOURCE_LAYOUT_DERIVED,
+} from "../types/keybinding";
 import type { VimCommand } from "../types/vim";
 import { CURRENT_KEYBINDING_VERSION } from "./storage";
 
@@ -41,7 +44,7 @@ export function deriveFromLayout(
       name: cmd.name,
       description: cmd.description,
       category: cmd.category,
-      source: "layout-derived",
+      source: KEYBINDING_SOURCE_LAYOUT_DERIVED,
       noremap: true,
     };
   });

--- a/src/utils/storage.test.ts
+++ b/src/utils/storage.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { KeybindingConfig } from "../types/keybinding";
+import { KEYBINDING_SOURCE_DEFAULT } from "../types/keybinding";
 import {
   CURRENT_KEYBINDING_VERSION,
   clearAllStorage,
@@ -401,7 +402,7 @@ describe("isStoredKeybindingConfig", () => {
       name: "下に移動",
       description: "カーソルを下に移動",
       category: "motion",
-      source: "default",
+      source: KEYBINDING_SOURCE_DEFAULT,
       noremap: true,
     };
 


### PR DESCRIPTION
## Summary
- `KeybindingSource` の各リテラル値（`"default"`, `"layout-derived"`, `"nvim-import"`, `"user-edit"`）を個別定数としてエクスポート
- 実装コード・テストコード全 16 ファイルのハードコードされたリテラルを定数参照に置換
- `as const satisfies KeybindingSource` 宣言で型安全性を維持

Closes #108

## Test plan
- [x] 新規テスト: 個別定数の値・KEYBINDING_SOURCES との整合性（5件）
- [x] 既存テスト: 778 tests passed
- [x] Biome check: PASSED
- [x] Build: PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)