### PR TITLE
refactor: <Plug> 判定ロジックを isPlugMapping に共通化 (#107)

### DIFF
--- a/src/utils/convert-nvim-to-keybinding.ts
+++ b/src/utils/convert-nvim-to-keybinding.ts
@@ -5,6 +5,7 @@ import {
 } from "../types/keybinding";
 import type { NvimMapping, VimCommand } from "../types/vim";
 import { expandNvimMapMode } from "../types/vim";
+import { isPlugMapping } from "./plug-mapping";
 
 export function convertNvimMapsToKeybindings(
   maps: NvimMapping[],
@@ -14,7 +15,7 @@ export function convertNvimMapsToKeybindings(
   const cmdByKey = new Map(vimCommands.map((c) => [c.key, c]));
 
   for (const map of maps) {
-    if (map.lhs.startsWith("<Plug>")) continue;
+    if (isPlugMapping(map.lhs)) continue;
 
     const matched = cmdByKey.get(map.lhs);
 

--- a/src/utils/merge-vim-commands.ts
+++ b/src/utils/merge-vim-commands.ts
@@ -1,6 +1,7 @@
 import type { VimMode } from "../types/keybinding";
 import type { MergedVimCommand, NvimMapping, VimCommand } from "../types/vim";
 import { DEFAULT_NVIM_MAP_CATEGORY, expandNvimMapMode } from "../types/vim";
+import { isPlugMapping } from "./plug-mapping";
 
 /**
  * ハードコードの Vim コマンドと nvim の実マッピングをマージする
@@ -22,7 +23,7 @@ export function mergeWithNvimMaps(
   const addedNewEntryKeys = new Set<string>();
 
   // <Plug> で始まるマップは全モードでスキップ
-  const validMaps = nvimMaps.filter((m) => !m.lhs.startsWith("<Plug>"));
+  const validMaps = nvimMaps.filter((m) => !isPlugMapping(m.lhs));
 
   for (const nvMap of validMaps) {
     const key = normalizeNvimKey(nvMap.lhs);

--- a/src/utils/nvim-map-parser.ts
+++ b/src/utils/nvim-map-parser.ts
@@ -1,4 +1,5 @@
 import type { NvimMapMode, NvimMapping, NvimMapSource } from "../types/vim";
+import { isPlugMapping } from "./plug-mapping";
 
 /**
  * `nvim --headless` の `verbose map` 出力をパースする
@@ -31,7 +32,7 @@ export function parseNvimMapOutput(raw: string): NvimMapping[] {
     const rhs = mapMatch[4].trimEnd();
 
     // <Plug> マッピングはスキップ
-    if (lhs.startsWith("<Plug>")) {
+    if (isPlugMapping(lhs)) {
       i++;
       // 後続の description/source 行をスキップ
       while (

--- a/src/utils/plug-mapping.test.ts
+++ b/src/utils/plug-mapping.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { isPlugMapping } from "./plug-mapping";
+
+describe("isPlugMapping", () => {
+  describe("true を返すケース", () => {
+    it("<Plug>foo は true を返す", () => {
+      expect(isPlugMapping("<Plug>foo")).toBe(true);
+    });
+
+    it("<Plug>(example) は true を返す", () => {
+      expect(isPlugMapping("<Plug>(example)")).toBe(true);
+    });
+  });
+
+  describe("false を返すケース", () => {
+    it("通常のキー j は false を返す", () => {
+      expect(isPlugMapping("j")).toBe(false);
+    });
+
+    it("空文字列は false を返す", () => {
+      expect(isPlugMapping("")).toBe(false);
+    });
+
+    it("Plug 以外の特殊キー <C-a> は false を返す", () => {
+      expect(isPlugMapping("<C-a>")).toBe(false);
+    });
+
+    it("不完全な形式 <Plug は false を返す", () => {
+      expect(isPlugMapping("<Plug")).toBe(false);
+    });
+  });
+});

--- a/src/utils/plug-mapping.ts
+++ b/src/utils/plug-mapping.ts
@@ -1,0 +1,6 @@
+/**
+ * `<Plug>` マッピングかどうかを判定する
+ */
+export function isPlugMapping(lhs: string): boolean {
+  return lhs.startsWith("<Plug>");
+}


### PR DESCRIPTION
Closes #107

## Summary
- `src/utils/plug-mapping.ts` に `isPlugMapping(lhs: string): boolean` を新規追加
- 3箇所の `lhs.startsWith("<Plug>")` ハードコードを `isPlugMapping()` 呼び出しに置換
  - `nvim-map-parser.ts`
  - `merge-vim-commands.ts`
  - `convert-nvim-to-keybinding.ts`

## Test plan
- [x] `plug-mapping.test.ts` — 6ケース（true 2件 / false 4件）全て PASS
- [x] 既存テスト 782 件に影響なし（全 PASS）
- [x] Biome check PASS
- [x] Build PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>