### PR TITLE
fix: session-done.sh の flock を POSIX 互換の mkdir ロックに置換

### DIFF
--- a/.claude/scripts/session-done.sh
+++ b/.claude/scripts/session-done.sh
@@ -10,7 +10,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 MANIFEST="$PROJECT_DIR/.claude/dispatch-manifest.json"
 DONE_DIR="$PROJECT_DIR/.claude/dispatch-done"
-LOCK_FILE="$PROJECT_DIR/.claude/dispatch.lock"
+LOCK_DIR="$PROJECT_DIR/.claude/dispatch.lock"
+LOCK_STALE_MINUTES=10
 
 # Worktree 削除ヘルパー
 cleanup_worktree() {
@@ -29,9 +30,16 @@ touch "$DONE_DIR/$ISSUE"
 
 [[ -f "$MANIFEST" ]] || { cleanup_worktree "$ISSUE"; exit 0; }
 
-# flock で排他制御（TOCTOU 防止）
-exec 9>"$LOCK_FILE"
-flock -x 9
+if [[ -d "$LOCK_DIR" ]] && find "$LOCK_DIR" -maxdepth 0 -mmin +"$LOCK_STALE_MINUTES" -print | grep -q .; then
+  rmdir "$LOCK_DIR" 2>/dev/null || true
+fi
+
+# mkdir による排他ロック（POSIX atomic）
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  cleanup_worktree "$ISSUE"
+  exit 0
+fi
+trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
 
 # バリアチェック: 現在セットの全セッション完了を確認（先頭1件に絞る）
 mapfile -t current_set < <(jq -r '([.sets[] | select(.status == "dispatched")][0].issues // []) | .[] | tostring' "$MANIFEST")
@@ -50,7 +58,9 @@ for num in "${current_set[@]}"; do rm -f "$DONE_DIR/$num"; done
 # 次の pending セットを取得
 next_issues=$(jq -r '[.sets[] | select(.status == "pending")][0].issues // empty' "$MANIFEST")
 if [[ -z "$next_issues" || "$next_issues" == "null" ]]; then
-  rm -f "$MANIFEST" "$LOCK_FILE"
+  rm -f "$MANIFEST"
+  rmdir "$LOCK_DIR" 2>/dev/null || true
+  trap - EXIT
   rmdir "$DONE_DIR" 2>/dev/null || true
   exit 0
 fi


### PR DESCRIPTION
## Summary
- `session-done.sh` の `flock`（Linux 専用）を `mkdir` ベースの排他ロックに置換し macOS 互換にした
- stale lock 検出: `find -mmin` で一定時間超過のロックを自動削除
- `trap EXIT` でスクリプト異常終了時もロック解放

Closes #223

## Test plan
- [ ] macOS (Homebrew/Nix なし) で session-done.sh が動作する
- [ ] 排他制御が正しく機能する（同時実行で片方が exit する）
- [ ] 異常終了後の再実行で stale lock が検出・解除される
- [ ] `flock` への依存が完全に除去されている（`grep flock` で 0 件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)