### PR TITLE
refactor: PracticePrompt の lastResult スタイリングを data-result 属性セレクタに移行

### DIFF
--- a/src/components/PracticeMode/PracticePrompt.module.css
+++ b/src/components/PracticeMode/PracticePrompt.module.css
@@ -7,11 +7,11 @@
   transition: border-color 0.3s;
 }
 
-.panel.correct {
+.panel[data-result="correct"] {
   border-color: var(--ctp-green);
 }
 
-.panel.incorrect {
+.panel[data-result="incorrect"] {
   border-color: var(--ctp-red);
 }
 

--- a/src/components/PracticeMode/PracticePrompt.tsx
+++ b/src/components/PracticeMode/PracticePrompt.tsx
@@ -1,6 +1,5 @@
 import { categoryColors, categoryLabels } from "../../data/vim-commands";
 import type { KeyInputSpec, PracticeScore, VimCommand } from "../../types/vim";
-import { cx } from "../../utils/cx";
 import styles from "./PracticePrompt.module.css";
 
 interface PracticePromptProps {
@@ -47,11 +46,7 @@ export function PracticePrompt({
 
   return (
     <div
-      className={cx(
-        styles.panel,
-        lastResult === "correct" && styles.correct,
-        lastResult === "incorrect" && styles.incorrect,
-      )}
+      className={styles.panel}
       data-testid="practice-prompt"
       data-result={lastResult}
     >


### PR DESCRIPTION
## Summary
- `.panel.correct` / `.panel.incorrect` CSS セレクタを `.panel[data-result="correct"]` / `.panel[data-result="incorrect"]` に変更
- `cx()` による className 条件分岐と `cx` インポートを PracticePrompt.tsx から削除
- `data-result` 属性は既存のため、CSS 側のみの変更でスタイリングが維持される

Closes #232

## Test plan
- [x] 既存テスト 23 件が全て PASS
- [x] local-ci: Biome PASS, Test PASS (782 tests), Build PASS
- [x] `data-result` 属性テスト（correct/incorrect/null）が引き続き PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>