### PR TITLE
feat: Lua エクスポートに desc オプションを追加

### DIFF
--- a/src/utils/keybinding-exporters.test.ts
+++ b/src/utils/keybinding-exporters.test.ts
@@ -123,7 +123,7 @@ describe("keybindingToLua", () => {
   });
 
   describe("noremap オプション", () => {
-    it('noremap: true の場合は { noremap = true, desc = "..." } オプションを付与する', () => {
+    it('noremap: true の場合は noremap を省略し { desc = "..." } のみ出力する', () => {
       const config = makeConfig({
         bindings: {
           ...emptyBindings(),
@@ -133,10 +133,11 @@ describe("keybindingToLua", () => {
 
       const result = keybindingToLua(config);
 
-      expect(result).toContain('{ noremap = true, desc = "テストコマンド" }');
+      expect(result).toContain('{ desc = "テストコマンド" }');
+      expect(result).not.toContain("noremap");
     });
 
-    it('noremap: false の場合は noremap を省略し { desc = "..." } のみ出力する', () => {
+    it('noremap: false の場合は { noremap = false, desc = "..." } オプションを付与する', () => {
       const config = makeConfig({
         bindings: {
           ...emptyBindings(),
@@ -146,8 +147,7 @@ describe("keybindingToLua", () => {
 
       const result = keybindingToLua(config);
 
-      expect(result).toContain('{ desc = "テストコマンド" }');
-      expect(result).not.toContain("noremap");
+      expect(result).toContain('{ noremap = false, desc = "テストコマンド" }');
     });
   });
 

--- a/src/utils/keybinding-exporters.ts
+++ b/src/utils/keybinding-exporters.ts
@@ -24,8 +24,8 @@ export function keybindingToLua(config: KeybindingConfig): string {
       const lhsEscaped = escapeLua(binding.lhs);
       const rhsEscaped = escapeLua(rhs);
       const opts: string[] = [];
-      if (binding.noremap) {
-        opts.push("noremap = true");
+      if (!binding.noremap) {
+        opts.push("noremap = false");
       }
       opts.push(`desc = "${escapeLua(binding.name)}"`);
       lines.push(


### PR DESCRIPTION
## Summary
- `keybindingToLua` の `vim.keymap.set()` 出力に `desc` オプションを追加
- `noremap = true` の場合: `{ desc = "..." }` のみ（vim.keymap.set() のデフォルトと同じため省略）
- `noremap = false` の場合: `{ noremap = false, desc = "..." }`
- `binding.name` の特殊文字（`\`, `"`）は `escapeLua()` でエスケープ

Closes #75

## Test plan
- [x] noremap テスト更新（true → 省略、false → 明示）
- [x] desc オプション新規テスト追加（3件: 基本出力、`"`エスケープ、`\`エスケープ）
- [x] 全55テスト PASS
- [x] local-ci（Biome / Test / Build）全 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)