### PR TITLE
fix: pre-push-check.sh の pnpm パス解決を常に Nix バイナリに変更 (#237)

### DIFF
--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -14,7 +14,7 @@ if [[ -z "$NON_CLAUDE_FILES" ]]; then
   exit 0
 fi
 
-PNPM=$( [ "$(git rev-parse --git-common-dir 2>/dev/null)" != ".git" ] && echo /etc/profiles/per-user/shiroino/bin/pnpm || echo pnpm )
+PNPM=/etc/profiles/per-user/shiroino/bin/pnpm
 
 TMPDIR_HOOK=$(mktemp -d "${TMPDIR:-/tmp}/pre-push-check.XXXXXX")
 trap 'rm -rf "$TMPDIR_HOOK"' EXIT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,17 +31,14 @@ VIA キーマップ読み込み時:
 2. 出力文字 → `invertKeymap()` で QWERTY 位置に逆引き（= langmap と同等の変換）
 3. QWERTY 位置 → Vim コマンドを引き当て
 
-## Worktree 環境での pnpm
+## サンドボックス環境での pnpm
 
-Worktree エージェント（sandbox 内）では `pnpm` シェル関数（safe-chain ラッパー）がプロキシサーバーの listen で EPERM になる。スキル・エージェントでは以下のワンライナーで worktree を検出し、直接バイナリにフォールバックする:
+Claude Code はすべてのコマンドをサンドボックス内で実行する。`pnpm` シェル関数（safe-chain ラッパー）はプロキシサーバーを listen しようとするため、サンドボックスのネットワーク制限で EPERM になる。スキル・エージェント・hook では常に Nix の pnpm バイナリを直接使用する:
 
 ```bash
-PNPM=$( [ "$(git rev-parse --git-common-dir 2>/dev/null)" != ".git" ] && echo /etc/profiles/per-user/shiroino/bin/pnpm || echo pnpm )
+PNPM=/etc/profiles/per-user/shiroino/bin/pnpm
 $PNPM lint
 ```
-
-- メインセッション（`.git` がディレクトリ）: `pnpm`（safe-chain 経由）
-- Worktree（`.git` がファイル）: Nix の pnpm バイナリを直接使用
 
 ## ロードマップ
 


### PR DESCRIPTION
## Summary
- `pre-push-check.sh` の pnpm パス解決を worktree 条件分岐から Nix バイナリ直接指定に変更
- CLAUDE.md の「Worktree 環境での pnpm」セクションを「サンドボックス環境での pnpm」に更新し、常に Nix バイナリを使用する方針を明文化

Closes #237

## Test plan
- [x] local-ci 全チェック PASS（Biome / Test 782件 / Build）
- [ ] メインセッションで `git push` 時に pre-push チェックが正常実行されることを確認
- [ ] Worktree セッションでも正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)