### PR TITLE
refactor: agents/skills の pnpm パス解決を CLAUDE.md 新方針に統一

### DIFF
--- a/.claude/agents/implement.md
+++ b/.claude/agents/implement.md
@@ -58,10 +58,10 @@ model: sonnet
 
 ## フォーマット自動修正
 
-実装が完了したら、完了報告の前に lint:fix を実行してください。worktree 環境では safe-chain ラッパーが sandbox で動作しないため、pnpm パスを自動解決する:
+実装が完了したら、完了報告の前に lint:fix を実行してください。sandbox 環境では safe-chain ラッパーが動作しないため、Nix の pnpm バイナリを直接使用する:
 
 ```bash
-PNPM=$( [ "$(git rev-parse --git-common-dir 2>/dev/null)" != ".git" ] && echo /etc/profiles/per-user/shiroino/bin/pnpm || echo pnpm )
+PNPM=/etc/profiles/per-user/shiroino/bin/pnpm
 $PNPM lint:fix
 ```
 

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -17,9 +17,9 @@ TDD のテスト実行と**状態判定**を担当するエージェントです
 
 ## テスト実行コマンド
 
-worktree 環境では safe-chain ラッパーが sandbox で動作しないため、pnpm パスを自動解決する。**全コマンドの先頭に以下を付与すること**:
+sandbox 環境では safe-chain ラッパーが動作しないため、Nix の pnpm バイナリを直接使用する。**全コマンドの先頭に以下を付与すること**:
 ```bash
-PNPM=$( [ "$(git rev-parse --git-common-dir 2>/dev/null)" != ".git" ] && echo /etc/profiles/per-user/shiroino/bin/pnpm || echo pnpm )
+PNPM=/etc/profiles/per-user/shiroino/bin/pnpm
 ```
 
 ### 全テスト実行

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -89,10 +89,10 @@ describe('targetFunction', () => {
 
 ## フォーマット自動修正
 
-テストファイルの作成が完了したら、lint:fix を実行してください。worktree 環境では safe-chain ラッパーが sandbox で動作しないため、pnpm パスを自動解決する:
+テストファイルの作成が完了したら、lint:fix を実行してください。sandbox 環境では safe-chain ラッパーが動作しないため、Nix の pnpm バイナリを直接使用する:
 
 ```bash
-PNPM=$( [ "$(git rev-parse --git-common-dir 2>/dev/null)" != ".git" ] && echo /etc/profiles/per-user/shiroino/bin/pnpm || echo pnpm )
+PNPM=/etc/profiles/per-user/shiroino/bin/pnpm
 $PNPM lint:fix
 ```
 

--- a/.claude/skills/local-ci/SKILL.md
+++ b/.claude/skills/local-ci/SKILL.md
@@ -11,10 +11,10 @@ user-invocable: true
 ## 実行手順
 
 1. 開始メッセージを表示: `Local CI を実行します...`
-2. 以下の 3 コマンドを **並列に Bash ツールで実行**（1 メッセージで 3 つの Bash tool call を送る）。各コマンドの先頭に worktree 検出の pnpm パス解決を付与する:
-   - `PNPM=$( [ "$(git rev-parse --git-common-dir 2>/dev/null)" != ".git" ] && echo /etc/profiles/per-user/shiroino/bin/pnpm || echo pnpm ) && $PNPM lint`
-   - `PNPM=$( [ "$(git rev-parse --git-common-dir 2>/dev/null)" != ".git" ] && echo /etc/profiles/per-user/shiroino/bin/pnpm || echo pnpm ) && $PNPM test`
-   - `PNPM=$( [ "$(git rev-parse --git-common-dir 2>/dev/null)" != ".git" ] && echo /etc/profiles/per-user/shiroino/bin/pnpm || echo pnpm ) && $PNPM build`
+2. 以下の 3 コマンドを **並列に Bash ツールで実行**（1 メッセージで 3 つの Bash tool call を送る）。sandbox 環境では safe-chain ラッパーが動作しないため、Nix の pnpm バイナリを直接使用する:
+   - `PNPM=/etc/profiles/per-user/shiroino/bin/pnpm && $PNPM lint`
+   - `PNPM=/etc/profiles/per-user/shiroino/bin/pnpm && $PNPM test`
+   - `PNPM=/etc/profiles/per-user/shiroino/bin/pnpm && $PNPM build`
 3. 各コマンドの **exit code** で PASS/FAIL を判定
 4. 結果をサマリーとして表示
 


### PR DESCRIPTION
## Summary
- agents/skills 内の pnpm パス解決で使われていた worktree 検出パターンを、CLAUDE.md の新方針（Nix バイナリ直接指定）に統一
- 対象: `test-writer.md`, `test-runner.md`, `implement.md`, `local-ci/SKILL.md` の4ファイル
- `dispatch-on-write.sh` と `tdd-next/SKILL.md` の `git rev-parse` は worktree 環境判定のためスコープ外

Closes #240

## Test plan
- [x] `.claude/` ディレクトリ内に pnpm パス解決の旧パターンが残っていないことを確認
- [x] Local CI (Biome, Test 785件, Build) 全て PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)