### PR TITLE
fix: セット間ディスパッチで main の merge --ff-only を追加

### DIFF
--- a/.claude/scripts/session-done.sh
+++ b/.claude/scripts/session-done.sh
@@ -65,8 +65,12 @@ if [[ -z "$next_issues" || "$next_issues" == "null" ]]; then
   exit 0
 fi
 
-# main を最新化（HEAD を変更しないよう fetch のみ）
-git -C "$PROJECT_DIR" fetch origin main 2>&1 || echo "fetch origin main failed, continuing with local state" >&2
+# main を最新化（fetch + merge --ff-only でワーキングツリーも更新）
+if git -C "$PROJECT_DIR" fetch origin main 2>&1; then
+  git -C "$PROJECT_DIR" merge --ff-only origin/main 2>&1 || echo "merge --ff-only origin/main failed, continuing with local state" >&2
+else
+  echo "fetch origin main failed, continuing with local state" >&2
+fi
 
 # 次セットを dispatched に更新
 jq '


### PR DESCRIPTION
## Summary
- `session-done.sh` の fetch 後に `merge --ff-only origin/main` を追加し、ローカル main のワーキングツリーを最新化
- fetch 失敗時は merge をスキップしてログノイズを抑制

Closes #246

## Test plan
- [ ] セット 1 マージ後にセット 2 をディスパッチし、worktree が最新 main を起点に作成されることを確認
- [ ] ネットワーク不通時に fetch 失敗ログが出力され、merge がスキップされることを確認
- [ ] main に uncommitted changes がある場合に merge --ff-only が失敗し、エラーログが出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)