### PR TITLE
refactor: convert-nvim-to-keybinding のマジック文字列を定数に置換

### DIFF
--- a/src/utils/convert-nvim-to-keybinding.test.ts
+++ b/src/utils/convert-nvim-to-keybinding.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { VimMode } from "../types/keybinding";
 import { KEYBINDING_SOURCE_NVIM_IMPORT } from "../types/keybinding";
 import type { NvimMapping, VimCommand } from "../types/vim";
+import { DEFAULT_NVIM_MAP_CATEGORY } from "../types/vim";
 import { convertNvimMapsToKeybindings } from "./convert-nvim-to-keybinding";
 
 const baseVimCommands: VimCommand[] = [
@@ -100,11 +101,11 @@ describe("convertNvimMapsToKeybindings", () => {
       expect(result.n[0].name).toBe("gd");
     });
 
-    it("VimCommand にマッチしないマップは category が 'misc' になる", () => {
+    it("VimCommand にマッチしないマップは category が DEFAULT_NVIM_MAP_CATEGORY になる", () => {
       const maps = [makeNvimMap({ lhs: "gd", mode: "n" })];
       const result = convertNvimMapsToKeybindings(maps, baseVimCommands);
 
-      expect(result.n[0].category).toBe("misc");
+      expect(result.n[0].category).toBe(DEFAULT_NVIM_MAP_CATEGORY);
     });
 
     it("VimCommand にマッチしないマップは commandId が設定されない", () => {

--- a/src/utils/convert-nvim-to-keybinding.ts
+++ b/src/utils/convert-nvim-to-keybinding.ts
@@ -4,7 +4,7 @@ import {
   KEYBINDING_SOURCE_NVIM_IMPORT,
 } from "../types/keybinding";
 import type { NvimMapping, VimCommand } from "../types/vim";
-import { expandNvimMapMode } from "../types/vim";
+import { DEFAULT_NVIM_MAP_CATEGORY, expandNvimMapMode } from "../types/vim";
 import { isPlugMapping } from "./plug-mapping";
 
 export function convertNvimMapsToKeybindings(
@@ -34,7 +34,7 @@ export function convertNvimMapsToKeybindings(
           rhs: map.rhs,
           name: map.lhs,
           description: map.description,
-          category: "misc",
+          category: DEFAULT_NVIM_MAP_CATEGORY,
           source: KEYBINDING_SOURCE_NVIM_IMPORT,
           noremap: map.noremap,
         };


### PR DESCRIPTION
## Summary
- `src/utils/convert-nvim-to-keybinding.ts` L37 のマジック文字列 `"misc"` を `DEFAULT_NVIM_MAP_CATEGORY` 定数に置換
- テストのアサーション・テスト名も定数参照に統一
- `merge-vim-commands.ts` と同じパターンに揃えるリファクタリング

Closes #234

## Test plan
- [x] 既存テスト 25 件が全て PASS
- [x] local-ci（Biome / Test 785件 / Build）全 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)