### PR TITLE
refactor: allSources 配列を定数に一元化

### DIFF
--- a/src/components/CommandReference/CommandReference.tsx
+++ b/src/components/CommandReference/CommandReference.tsx
@@ -15,7 +15,11 @@ import type {
   VimCommandCategory,
   VimCommandSource,
 } from "../../types/vim";
-import { matchesVimMode, VIM_COMMAND_CATEGORIES } from "../../types/vim";
+import {
+  matchesVimMode,
+  VIM_COMMAND_CATEGORIES,
+  VIM_COMMAND_SOURCES,
+} from "../../types/vim";
 import { cx } from "../../utils/cx";
 import { resolveVimKey } from "../../utils/vim-key-resolver";
 import styles from "./CommandReference.module.css";
@@ -104,13 +108,6 @@ function vimKeyToHighlights(
   return entries;
 }
 
-const allSources: VimCommandSource[] = [
-  "hardcoded",
-  "nvim-default",
-  "plugin",
-  "user",
-];
-
 export function CommandReference({
   customKeymap,
   viaKeymapFull,
@@ -122,7 +119,7 @@ export function CommandReference({
     Set<VimCommandCategory>
   >(new Set(VIM_COMMAND_CATEGORIES));
   const [selectedSources, setSelectedSources] = useState<Set<VimCommandSource>>(
-    new Set(allSources),
+    new Set(VIM_COMMAND_SOURCES),
   );
   const [searchText, setSearchText] = useState("");
 
@@ -236,7 +233,7 @@ export function CommandReference({
         </div>
         {hasSources && (
           <div className={styles.sources}>
-            {allSources.map((src) => (
+            {VIM_COMMAND_SOURCES.map((src) => (
               <button
                 type="button"
                 key={src}

--- a/src/types/vim.test.ts
+++ b/src/types/vim.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it, test } from "vitest";
-import type { NvimMapMode, VimCommandCategory, VimMode } from "./vim";
+import type {
+  NvimMapMode,
+  VimCommandCategory,
+  VimCommandSource,
+  VimMode,
+} from "./vim";
 import {
   expandNvimMapMode,
   matchesVimMode,
   VIM_COMMAND_CATEGORIES,
+  VIM_COMMAND_SOURCES,
   VIM_PRACTICE_CATEGORIES,
 } from "./vim";
 
@@ -197,5 +203,28 @@ describe("VIM_PRACTICE_CATEGORIES", () => {
   test("重複がない", () => {
     const unique = new Set<string>(VIM_PRACTICE_CATEGORIES);
     expect(unique.size).toBe(VIM_PRACTICE_CATEGORIES.length);
+  });
+});
+
+describe("VIM_COMMAND_SOURCES", () => {
+  test("4つの要素を持つ", () => {
+    expect(VIM_COMMAND_SOURCES).toHaveLength(4);
+  });
+
+  describe("全ての VimCommandSource 値を含む", () => {
+    const cases: VimCommandSource[] = [
+      "hardcoded",
+      "nvim-default",
+      "plugin",
+      "user",
+    ];
+    test.each(cases)('"%s" を含む', (source) => {
+      expect(VIM_COMMAND_SOURCES).toContain(source);
+    });
+  });
+
+  test("重複がない", () => {
+    const unique = new Set<string>(VIM_COMMAND_SOURCES);
+    expect(unique.size).toBe(VIM_COMMAND_SOURCES.length);
   });
 });

--- a/src/types/vim.ts
+++ b/src/types/vim.ts
@@ -94,6 +94,14 @@ export function matchesVimMode(
 
 export type VimCommandSource = "hardcoded" | NvimMapSource;
 
+/** VimCommandSource の全値リスト */
+export const VIM_COMMAND_SOURCES = [
+  "hardcoded",
+  "nvim-default",
+  "plugin",
+  "user",
+] as const satisfies VimCommandSource[];
+
 export interface MergedVimCommand extends VimCommand {
   source: VimCommandSource;
   nvimOverride?: boolean;


### PR DESCRIPTION
## Summary
- `VIM_COMMAND_SOURCES` 定数を `src/types/vim.ts` に追加（`VIM_COMMAND_CATEGORIES` と同パターン）
- `CommandReference.tsx` のローカル `allSources` 配列を `VIM_COMMAND_SOURCES` インポートに置換

Closes #252

## Test plan
- [x] `VIM_COMMAND_SOURCES` が全4値を網羅するユニットテスト追加
- [x] 既存テスト全パス (2139 tests)
- [x] Biome check / Build パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)