### PR TITLE
refactor: CommandReference の toggle 関数に useCallback 適用

### DIFF
--- a/src/components/CommandReference/CommandReference.test.tsx
+++ b/src/components/CommandReference/CommandReference.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, test, vi } from "vitest";
 import type { MergedVimCommand } from "../../types/vim";
 import { CommandReference } from "./CommandReference";
@@ -145,5 +146,194 @@ describe("CommandReference モードフィルタリング", () => {
         screen.getByText("Visual+Select command in Select mode name"),
       ).toBeInTheDocument();
     });
+  });
+});
+
+describe("CommandReference toggleCategory", () => {
+  const motionCommand: MergedVimCommand = {
+    key: "h",
+    name: "Left",
+    description: "Move cursor left",
+    category: "motion",
+    source: "hardcoded",
+    modes: ["n"],
+  };
+  const editCommand: MergedVimCommand = {
+    key: "u",
+    name: "undo",
+    description: "元に戻す",
+    category: "edit",
+    source: "hardcoded",
+    modes: ["n"],
+  };
+
+  test("motion カテゴリボタンをクリックすると motion コマンドが非表示になる", async () => {
+    const user = userEvent.setup();
+    render(
+      <CommandReference
+        {...defaultProps}
+        mergedCommands={[motionCommand, editCommand]}
+        activeVimMode="n"
+      />,
+    );
+
+    expect(screen.getByText("Left")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "移動" }));
+
+    expect(screen.queryByText("Left")).not.toBeInTheDocument();
+  });
+
+  test("非表示にした motion カテゴリボタンを再クリックすると motion コマンドが再表示される", async () => {
+    const user = userEvent.setup();
+    render(
+      <CommandReference
+        {...defaultProps}
+        mergedCommands={[motionCommand, editCommand]}
+        activeVimMode="n"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "移動" }));
+    expect(screen.queryByText("Left")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "移動" }));
+    expect(screen.getByText("Left")).toBeInTheDocument();
+  });
+
+  test("カテゴリが1つだけ選択されている状態でそのボタンをクリックしても解除されない", async () => {
+    const user = userEvent.setup();
+    render(
+      <CommandReference
+        {...defaultProps}
+        mergedCommands={[motionCommand]}
+        activeVimMode="n"
+      />,
+    );
+
+    // edit カテゴリをすべて除外して motion だけ残す（他カテゴリを全部 OFF にする）
+    // まず edit 以外を全部クリックして motion だけ残す
+    const allCategoryButtons = [
+      "編集",
+      "検索",
+      "挿入",
+      "ビジュアル",
+      "オペレータ",
+      "テキストオブジェクト",
+      "その他",
+    ];
+    for (const label of allCategoryButtons) {
+      await user.click(screen.getByRole("button", { name: label }));
+    }
+
+    // この時点で motion のみ選択された状態
+    expect(screen.getByText("Left")).toBeInTheDocument();
+
+    // 最後の1つ（移動）をクリックしても解除されないことを確認
+    await user.click(screen.getByRole("button", { name: "移動" }));
+    expect(screen.getByText("Left")).toBeInTheDocument();
+  });
+});
+
+describe("CommandReference toggleSource", () => {
+  const hardcodedCommand: MergedVimCommand = {
+    key: "h",
+    name: "Hardcoded command name",
+    description: "Hardcoded command desc",
+    category: "motion",
+    source: "hardcoded",
+    modes: ["n"],
+  };
+  const nvimDefaultCommand: MergedVimCommand = {
+    key: "j",
+    name: "Nvim default command name",
+    description: "Nvim default command desc",
+    category: "motion",
+    source: "nvim-default",
+    modes: ["n"],
+  };
+
+  test("ソースボタンは mergedCommands が渡されたときのみ表示される", () => {
+    render(
+      <CommandReference
+        {...defaultProps}
+        mergedCommands={[hardcodedCommand]}
+        activeVimMode="n"
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Vim 標準" }),
+    ).toBeInTheDocument();
+  });
+
+  test("ソースボタンは mergedCommands がない場合は表示されない", () => {
+    render(<CommandReference {...defaultProps} />);
+
+    expect(
+      screen.queryByRole("button", { name: "Vim 標準" }),
+    ).not.toBeInTheDocument();
+  });
+
+  test("Vim 標準ボタンをクリックすると hardcoded コマンドが非表示になる", async () => {
+    const user = userEvent.setup();
+    render(
+      <CommandReference
+        {...defaultProps}
+        mergedCommands={[hardcodedCommand, nvimDefaultCommand]}
+        activeVimMode="n"
+      />,
+    );
+
+    expect(screen.getByText("Hardcoded command name")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Vim 標準" }));
+
+    expect(
+      screen.queryByText("Hardcoded command name"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("非表示にした Vim 標準ボタンを再クリックすると hardcoded コマンドが再表示される", async () => {
+    const user = userEvent.setup();
+    render(
+      <CommandReference
+        {...defaultProps}
+        mergedCommands={[hardcodedCommand, nvimDefaultCommand]}
+        activeVimMode="n"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Vim 標準" }));
+    expect(
+      screen.queryByText("Hardcoded command name"),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Vim 標準" }));
+    expect(screen.getByText("Hardcoded command name")).toBeInTheDocument();
+  });
+
+  test("ソースが1つだけ選択されている状態でそのボタンをクリックしても解除されない", async () => {
+    const user = userEvent.setup();
+    render(
+      <CommandReference
+        {...defaultProps}
+        mergedCommands={[hardcodedCommand]}
+        activeVimMode="n"
+      />,
+    );
+
+    // nvim-default / plugin / user を OFF にして hardcoded だけ残す
+    const otherSourceButtons = ["Neovim", "プラグイン", "ユーザー設定"];
+    for (const label of otherSourceButtons) {
+      await user.click(screen.getByRole("button", { name: label }));
+    }
+
+    // この時点で hardcoded のみ選択された状態
+    expect(screen.getByText("Hardcoded command name")).toBeInTheDocument();
+
+    // 最後の1つ（Vim 標準）をクリックしても解除されないことを確認
+    await user.click(screen.getByRole("button", { name: "Vim 標準" }));
+    expect(screen.getByText("Hardcoded command name")).toBeInTheDocument();
   });
 });

--- a/src/components/CommandReference/CommandReference.tsx
+++ b/src/components/CommandReference/CommandReference.tsx
@@ -181,7 +181,7 @@ export function CommandReference({
     return groups;
   }, [filteredCommands]);
 
-  const toggleCategory = (cat: VimCommandCategory) => {
+  const toggleCategory = useCallback((cat: VimCommandCategory) => {
     setSelectedCategories((prev) => {
       const next = new Set(prev);
       if (next.has(cat)) {
@@ -191,9 +191,9 @@ export function CommandReference({
       }
       return next;
     });
-  };
+  }, []);
 
-  const toggleSource = (src: VimCommandSource) => {
+  const toggleSource = useCallback((src: VimCommandSource) => {
     setSelectedSources((prev) => {
       const next = new Set(prev);
       if (next.has(src)) {
@@ -203,7 +203,7 @@ export function CommandReference({
       }
       return next;
     });
-  };
+  }, []);
 
   return (
     <div className={styles.container}>


### PR DESCRIPTION
## Summary
- `CommandReference.tsx` の `toggleCategory` / `toggleSource` を `useCallback` でラップ
- `usePractice.ts` の `toggleCategory` と同パターンに統一（空依存配列で安定参照）
- toggle 動作のテスト（カテゴリ・ソースフィルタ、最低1つ選択ガード）を追加

Closes #253

## Test plan
- [x] 既存テスト全26件 pass
- [x] Biome check pass
- [x] TypeScript 型チェック pass
- [x] プロダクションビルド pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)