### PR TITLE
refactor: CommandReference の as MergedVimCommand を型ガードに置換 (#255)

### DIFF
--- a/src/components/CommandReference/CommandReference.tsx
+++ b/src/components/CommandReference/CommandReference.tsx
@@ -16,6 +16,7 @@ import type {
   VimCommandSource,
 } from "../../types/vim";
 import {
+  isMergedVimCommand,
   matchesVimMode,
   VIM_COMMAND_CATEGORIES,
   VIM_COMMAND_SOURCES,
@@ -144,11 +145,10 @@ export function CommandReference({
       const modes = cmd.modes ?? ["n"];
       if (!matchesVimMode(modes, activeVimMode)) return false;
       if (!selectedCategories.has(cmd.category)) return false;
-      if (
-        hasSources &&
-        !selectedSources.has((cmd as MergedVimCommand).source ?? "hardcoded")
-      )
-        return false;
+      if (hasSources) {
+        const source = isMergedVimCommand(cmd) ? cmd.source : "hardcoded";
+        if (!selectedSources.has(source)) return false;
+      }
       if (searchText === "") return true;
       return (
         cmd.key.toLowerCase().includes(lowerSearch) ||
@@ -292,7 +292,9 @@ export function CommandReference({
                     viaKeymapFull,
                   );
                   const isDifferent = translated !== cmd.key;
-                  const source = (cmd as MergedVimCommand).source;
+                  const source = isMergedVimCommand(cmd)
+                    ? cmd.source
+                    : "hardcoded";
                   return (
                     <tr
                       key={cmd.key}

--- a/src/types/vim.test.ts
+++ b/src/types/vim.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it, test } from "vitest";
 import type {
+  MergedVimCommand,
   NvimMapMode,
+  VimCommand,
   VimCommandCategory,
   VimCommandSource,
   VimMode,
 } from "./vim";
 import {
   expandNvimMapMode,
+  isMergedVimCommand,
   matchesVimMode,
   VIM_COMMAND_CATEGORIES,
   VIM_COMMAND_SOURCES,
@@ -226,5 +229,71 @@ describe("VIM_COMMAND_SOURCES", () => {
   test("重複がない", () => {
     const unique = new Set<string>(VIM_COMMAND_SOURCES);
     expect(unique.size).toBe(VIM_COMMAND_SOURCES.length);
+  });
+});
+
+describe("isMergedVimCommand", () => {
+  const baseVimCommand: VimCommand = {
+    key: "h",
+    name: "左に移動",
+    description: "カーソルを左に1文字移動する",
+    category: "motion",
+  };
+
+  describe("正常系", () => {
+    it("source プロパティを持つ MergedVimCommand に対して true を返す", () => {
+      const mergedCmd: MergedVimCommand = {
+        ...baseVimCommand,
+        source: "hardcoded",
+      };
+      expect(isMergedVimCommand(mergedCmd)).toBe(true);
+    });
+
+    it("source が nvim-default の MergedVimCommand に対して true を返す", () => {
+      const mergedCmd: MergedVimCommand = {
+        ...baseVimCommand,
+        source: "nvim-default",
+      };
+      expect(isMergedVimCommand(mergedCmd)).toBe(true);
+    });
+
+    it("source が plugin の MergedVimCommand に対して true を返す", () => {
+      const mergedCmd: MergedVimCommand = {
+        ...baseVimCommand,
+        source: "plugin",
+      };
+      expect(isMergedVimCommand(mergedCmd)).toBe(true);
+    });
+
+    it("source が user の MergedVimCommand に対して true を返す", () => {
+      const mergedCmd: MergedVimCommand = {
+        ...baseVimCommand,
+        source: "user",
+      };
+      expect(isMergedVimCommand(mergedCmd)).toBe(true);
+    });
+
+    it("nvimOverride を持つ MergedVimCommand に対して true を返す", () => {
+      const mergedCmd: MergedVimCommand = {
+        ...baseVimCommand,
+        source: "nvim-default",
+        nvimOverride: true,
+      };
+      expect(isMergedVimCommand(mergedCmd)).toBe(true);
+    });
+  });
+
+  describe("source プロパティを持たない VimCommand", () => {
+    it("source プロパティを持たない VimCommand に対して false を返す", () => {
+      expect(isMergedVimCommand(baseVimCommand)).toBe(false);
+    });
+
+    it("modes を持つ VimCommand でも source がなければ false を返す", () => {
+      const cmdWithModes: VimCommand = {
+        ...baseVimCommand,
+        modes: ["n", "v"],
+      };
+      expect(isMergedVimCommand(cmdWithModes)).toBe(false);
+    });
   });
 });

--- a/src/types/vim.ts
+++ b/src/types/vim.ts
@@ -107,6 +107,10 @@ export interface MergedVimCommand extends VimCommand {
   nvimOverride?: boolean;
 }
 
+export function isMergedVimCommand(cmd: VimCommand): cmd is MergedVimCommand {
+  return "source" in cmd;
+}
+
 export interface VimCommand {
   /** Vim のキー (QWERTY基準) */
   key: string;


### PR DESCRIPTION
## Summary

- `src/types/vim.ts` に `isMergedVimCommand` 型ガード関数を追加
- `CommandReference.tsx` の 2箇所の `as MergedVimCommand` 型アサーションを型ガードに置換
- 型ガード関数のユニットテスト（7件）を追加

Closes #255

## Test plan

- [x] `isMergedVimCommand` ユニットテスト（正常系5件 + 異常系2件）
- [x] `CommandReference.test.tsx` 既存テスト回帰確認（26件）
- [x] 全テスト通過（2154件）
- [x] Biome lint PASS
- [x] tsc + vite build PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)