### PR TITLE
refactor: vim.ts の型定義順序を依存関係順に整理 (#259)

### DIFF
--- a/src/types/vim.ts
+++ b/src/types/vim.ts
@@ -102,15 +102,6 @@ export const VIM_COMMAND_SOURCES = [
   "user",
 ] as const satisfies VimCommandSource[];
 
-export interface MergedVimCommand extends VimCommand {
-  source: VimCommandSource;
-  nvimOverride?: boolean;
-}
-
-export function isMergedVimCommand(cmd: VimCommand): cmd is MergedVimCommand {
-  return "source" in cmd;
-}
-
 export interface VimCommand {
   /** Vim のキー (QWERTY基準) */
   key: string;
@@ -122,6 +113,15 @@ export interface VimCommand {
   category: VimCommandCategory;
   /** 適用モード（省略時は ["n"]） */
   modes?: VimMode[];
+}
+
+export interface MergedVimCommand extends VimCommand {
+  source: VimCommandSource;
+  nvimOverride?: boolean;
+}
+
+export function isMergedVimCommand(cmd: VimCommand): cmd is MergedVimCommand {
+  return "source" in cmd;
 }
 
 /** QWERTY キー → カスタム配列キー のマッピング */


### PR DESCRIPTION
## Summary
- `src/types/vim.ts` の型定義順序を `VimCommand` → `MergedVimCommand` → `isMergedVimCommand` の依存順に並べ替え
- 前方参照を解消し可読性を向上（ロジック変更なし）

Closes #259

## Test plan
- [x] `pnpm exec tsc --noEmit` PASS
- [x] 既存テスト 2154 tests PASS
- [x] `pnpm build` PASS
- [x] Biome lint PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)